### PR TITLE
Speedup the Equal(and NotEqual) Op in SecureNN with 3x increase

### DIFF
--- a/cc/modules/protocol/mpc/snn/include/opsets_base.h
+++ b/cc/modules/protocol/mpc/snn/include/opsets_base.h
@@ -418,41 +418,76 @@ class OpBase_ {
     if (r_type == "a_1") {
       assert((partyNum == PARTY_A || partyNum == PARTY_C) && "Only A and C can call for a_1");
       assert(neg_type == "POSITIVE" && "neg_type should be POSITIVE");
-      assert(sizeof(T) == sizeof(mpc_t) && "sizeof(T) == sizeof(mpc_t)");
-      for (size_t i = 0; i < size; ++i)
-        vec[i] = aes_a_1->get64Bits();
+      // assert(sizeof(T) == sizeof(mpc_t) && "sizeof(T) == sizeof(mpc_t)");
+      // for (size_t i = 0; i < size; ++i)
+      //  vec[i] = aes_a_1->get64Bits();
+      if (sizeof(T) == sizeof(mpc_t)) {
+        for (size_t i = 0; i < size; ++i)
+          vec[i] = aes_a_1->get64Bits();
+      } else {
+        for (size_t i = 0; i < size; ++i)
+          vec[i] = aes_a_1->get8Bits();
+      }
     }
 
     if (r_type == "b_1") {
       assert((partyNum == PARTY_A || partyNum == PARTY_C) && "Only A and C can call for b_1");
       assert(neg_type == "POSITIVE" && "neg_type should be POSITIVE");
-      assert(sizeof(T) == sizeof(mpc_t) && "sizeof(T) == sizeof(mpc_t)");
-      for (size_t i = 0; i < size; ++i)
-        vec[i] = aes_b_1->get64Bits();
+      // assert(sizeof(T) == sizeof(mpc_t) && "sizeof(T) == sizeof(mpc_t)");
+      // for (size_t i = 0; i < size; ++i)
+      //   vec[i] = aes_b_1->get64Bits();
+      if (sizeof(T) == sizeof(mpc_t)) {
+        for (size_t i = 0; i < size; ++i)
+          vec[i] = aes_b_1->get64Bits();
+      } else {
+        for (size_t i = 0; i < size; ++i)
+          vec[i] = aes_b_1->get8Bits();
+      }      
     }
 
     if (r_type == "c_1") {
       assert((partyNum == PARTY_A || partyNum == PARTY_C) && "Only A and C can call for c_1");
       assert(neg_type == "POSITIVE" && "neg_type should be POSITIVE");
-      assert(sizeof(T) == sizeof(mpc_t) && "sizeof(T) == sizeof(mpc_t)");
-      for (size_t i = 0; i < size; ++i)
-        vec[i] = aes_c_1->get64Bits();
+      // assert(sizeof(T) == sizeof(mpc_t) && "sizeof(T) == sizeof(mpc_t)");
+      // for (size_t i = 0; i < size; ++i)
+      //   vec[i] = aes_c_1->get64Bits();
+      if (sizeof(T) == sizeof(mpc_t)) {
+        for (size_t i = 0; i < size; ++i)
+          vec[i] = aes_c_1->get64Bits();
+      } else {
+        for (size_t i = 0; i < size; ++i)
+          vec[i] = aes_c_1->get8Bits();
+      }       
     }
 
     if (r_type == "a_2") {
       assert((partyNum == PARTY_B || partyNum == PARTY_C) && "Only B and C can call for a_2");
       assert(neg_type == "POSITIVE" && "neg_type should be POSITIVE");
-      assert(sizeof(T) == sizeof(mpc_t) && "sizeof(T) == sizeof(mpc_t)");
-      for (size_t i = 0; i < size; ++i)
-        vec[i] = aes_a_2->get64Bits();
+      // assert(sizeof(T) == sizeof(mpc_t) && "sizeof(T) == sizeof(mpc_t)");
+      // for (size_t i = 0; i < size; ++i)
+      //   vec[i] = aes_a_2->get64Bits();
+      if (sizeof(T) == sizeof(mpc_t)) {
+        for (size_t i = 0; i < size; ++i)
+          vec[i] = aes_a_2->get64Bits();
+      } else {
+        for (size_t i = 0; i < size; ++i)
+          vec[i] = aes_a_2->get8Bits();
+      }            
     }
 
     if (r_type == "b_2") {
       assert((partyNum == PARTY_B || partyNum == PARTY_C) && "Only B and C can call for b_2");
       assert(neg_type == "POSITIVE" && "neg_type should be POSITIVE");
-      assert(sizeof(T) == sizeof(mpc_t) && "sizeof(T) == sizeof(mpc_t)");
-      for (size_t i = 0; i < size; ++i)
-        vec[i] = aes_b_2->get64Bits();
+      // assert(sizeof(T) == sizeof(mpc_t) && "sizeof(T) == sizeof(mpc_t)");
+      // for (size_t i = 0; i < size; ++i)
+      //   vec[i] = aes_b_2->get64Bits();
+      if (sizeof(T) == sizeof(mpc_t)) {
+        for (size_t i = 0; i < size; ++i)
+          vec[i] = aes_b_2->get64Bits();
+      } else {
+        for (size_t i = 0; i < size; ++i)
+          vec[i] = aes_b_2->get8Bits();
+      }       
     }
   }
 
@@ -559,6 +594,17 @@ class OpBase_ {
   void synchronize(const msg_id_t& msg_id);
 
  public:
+ // Added in 20200928 by Junjie Shi, and used by Equal only for now.
+ // Attention!! only the LAST bit is USED!!
+  void sendBitVector(const vector<small_mpc_t>& vec, size_t player, size_t size);
+  void receiveBitVector(vector<small_mpc_t>& vec, size_t player, size_t size);
+  void sendTwoBitVector(const vector<small_mpc_t>& vec_a,
+                        const vector<small_mpc_t>& vec_b,
+                        size_t player, size_t size_a, size_t size_b);
+  void receiveTwoBitVector(vector<small_mpc_t>& vec_a,
+                        vector<small_mpc_t>& vec_b,
+                        size_t player, size_t size_a, size_t size_b);
+
   template <typename T>
   void sendVector(const vector<T>& vec, size_t player, size_t size) {
     sendBuf(player, (const char*)vec.data(), size * sizeof(T), 0);
@@ -568,6 +614,7 @@ class OpBase_ {
   void receiveVector(vector<T>& vec, size_t player, size_t size) {
     receiveBuf(player, (char*)vec.data(), size * sizeof(T), 0);
   }
+
 
   template <typename T>
   void sendTwoVectors(

--- a/cc/modules/protocol/mpc/snn/include/snn_opsets.h
+++ b/cc/modules/protocol/mpc/snn/include/snn_opsets.h
@@ -1047,6 +1047,10 @@ class DotProduct : public BinaryOp {
     return funcBinaryOp(b, a, c, size);
   }
 
+public:
+  // this is actually the AND functionality for bit-share.
+  int BitMul(const vector<small_mpc_t>& a, const vector<small_mpc_t>& b, vector<small_mpc_t> & c, size_t size);
+
  private:
   int funcDotProduct(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size);
 };
@@ -1483,11 +1487,22 @@ class Equal : public CompareOp {
     const vector<mpc_t>& b,
     vector<mpc_t>& c,
     size_t size) {
-    return funcEqual(a, b, c, size);
+    return funcFastEqual(a, b, c, size);
   }
 
- private:
+// temp make these as public funcs
+public:
+  // retired! NOT use this any more.
   int funcEqual(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size);
+  // Optimized version, default one.
+  int funcFastEqual(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size);
+  
+  // for each a_i in a, get a_i[0] AND a_i[1] AND a_i[2] ... AND a_i[n] as c[i]
+  int FanInBitAdd(const vector<vector<small_mpc_t>>& a,
+                  vector<small_mpc_t>& c,
+                  size_t size);
+  // convert binary bit-share to arithematic share of the same plain value.
+  int B2A(const vector<small_mpc_t>& bit_shares, vector<mpc_t>& arith_shares, size_t size);
 };
 
 class NotEqual : public CompareOp {
@@ -1499,11 +1514,14 @@ class NotEqual : public CompareOp {
     vector<mpc_t>& c,
     size_t size) {
     c.resize(size);
-    return funcNotEqual(a, b, c, size);
+    return funcFastNotEqual(a, b, c, size);
   }
 
- private:
+private:
+  // retired! NOT use this any more.
   int funcNotEqual(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size);
+    // Optimized version, default one.
+  int funcFastNotEqual(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size);
 };
 
 class Less : public CompareOp {
@@ -1518,7 +1536,7 @@ class Less : public CompareOp {
     return funcLess(a, b, c, size);
   }
 
- private:
+private:
   int funcLess(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size);
 };
 

--- a/cc/modules/protocol/mpc/snn/src/impl/compare.cpp
+++ b/cc/modules/protocol/mpc/snn/src/impl/compare.cpp
@@ -16,6 +16,7 @@
 // along with the Rosetta library. If not, see <http://www.gnu.org/licenses/>.
 // ==============================================================================
 #include "cc/modules/protocol/mpc/snn/src/impl/op_impl.h"
+#include <cmath>
 
 namespace rosetta {
 namespace snn {
@@ -75,6 +76,242 @@ int Equal::funcEqual(const vector<mpc_t> &a, const vector<mpc_t> &b, vector<mpc_
   return 0;
 }
 
+int Equal::funcFastEqual(const vector<mpc_t> &a, const vector<mpc_t> &b, vector<mpc_t> &c, size_t size)
+{
+  if (validate_input(a, b, c, size) != 0)
+  {
+    log_error << "invald inputs:  " << __FILE__ << ":" << __LINE__ << "  " << __FUNCTION__ << endl;
+    throw;
+  }
+  vector<mpc_t> z(size, 0);
+  subtractVectors<mpc_t>(a, b, z, size);
+
+  vector<mpc_t> r_0(size, 0);
+  vector<mpc_t> r_1(size, 0);
+  vector<mpc_t> r(size, 0);
+  if (HELPER) {
+    // fixed for debuging
+    // r_0 = vector<mpc_t>(size, 2 << FLOAT_PRECISION_M);
+    // r_1 = vector<mpc_t>(size, 3 << FLOAT_PRECISION_M);
+    // r = vector<mpc_t>(size, 5 << FLOAT_PRECISION_M);
+    populateRandomVector<mpc_t>(r_0, size, "a_1", "POSITIVE");
+    populateRandomVector<mpc_t>(r_1, size, "a_2", "POSITIVE");
+    addVectors<mpc_t>(r_0, r_1, r, size);
+  } else if (partyNum == PARTY_A) {
+    // fixed for debuging
+    // r_0 = vector<mpc_t>(size, 2 << FLOAT_PRECISION_M);
+    populateRandomVector<mpc_t>(r_0, size, "a_1", "POSITIVE");
+    r = r_0;
+  } else if (partyNum == PARTY_B) {
+    // fixed for debuging
+    // r_1 = vector<mpc_t>(size, 3 << FLOAT_PRECISION_M);
+    populateRandomVector<mpc_t>(r_1, size, "a_2", "POSITIVE");
+    r = r_1;
+  }
+
+  // share r in binary-xor format
+  vector<mpc_t> r_0_b(size, 0);
+  vector<mpc_t> r_1_b(size, 0);
+  
+  // this is for interface compliance with communication.
+  // Note that the all the inner vectors have the same size: sizeof(mpc_t)! 
+  int BIT_L = sizeof(mpc_t) * 8;
+  vector<vector<small_mpc_t>> bit_share(size, vector<small_mpc_t>(BIT_L, 0));
+  
+  if (HELPER || partyNum == PARTY_A) {
+    // fixed for debuging
+    // r_0_b = vector<mpc_t>(size, 2 << FLOAT_PRECISION_M);
+    populateRandomVector<mpc_t>(r_0_b, size, "a_1", "POSITIVE");
+  }
+  if(HELPER) {
+    for(size_t i = 0; i < size; ++i) {
+      r_1_b[i] = r[i] ^ r_0_b[i];
+    }
+    sendVector<mpc_t>(r_1_b, PARTY_B, size);
+  }
+  if(partyNum == PARTY_B) {
+    receiveVector<mpc_t>(r_1_b, PARTY_C, size);
+  }
+
+  // GetMpcOpInner(Reconstruct2PC)->Run(z, z.size(), "input z res");
+  // reveal plaintext: Z + r
+  addVectors<mpc_t>(z, r, z, size);
+  // GetMpcOpInner(Reconstruct2PC)->Run(r, r.size(), "mask r res");
+  // GetMpcOpInner(Reconstruct2PC)->Run(z, z.size(), "masked Z res");
+  vector<mpc_t> plain_z(size, 0);
+  if(PRIMARY) {
+    thread* exchange_threads = new thread[2];
+    exchange_threads[0] = thread(&OpBase_::sendVector<mpc_t>, 
+                            this, ref(z), adversary(partyNum), size);
+    exchange_threads[1] = thread(&OpBase_::receiveVector<mpc_t>, 
+                            this, ref(plain_z), adversary(partyNum), size);
+    exchange_threads[0].join();
+    exchange_threads[1].join();
+    delete[] exchange_threads;
+
+    addVectors<mpc_t>(z, plain_z, plain_z, size);
+    // print_vec(plain_z, size, "plain masked Z");
+
+    for (size_t i = 0; i < size; ++i) {
+      // cout << "debug:" << i << "-th local bit-share: " << r_0_b[i] << " and " << plain_z[i];
+      mpc_t tmp_v = ~ (r_0_b[i] ^ plain_z[i]);
+      for (size_t j = 0; j < BIT_L; ++j) {
+        if (partyNum == PARTY_B) {
+          bit_share[i][j] = (r_1_b[i] >> j) & 0x01;
+          // cout << int(bit_share[i][j]);
+        } else if (partyNum == PARTY_A) {
+          bit_share[i][j] = (tmp_v >> j) & 0x01;
+          // cout << int(bit_share[i][j]);
+        }
+      }
+      // cout << endl;
+    }
+  }
+  
+
+  vector<small_mpc_t> res(size, 0);
+  // // tmp debugging:
+  // vector<vector<small_mpc_t>> tmp_share(1, vector<small_mpc_t>(64, 0));
+  // vector<mpc_t> tmp_c(1, 0);
+  // if (partyNum == PARTY_A) {
+  //   tmp_share[0] = bit_share[5];
+  // } else if (partyNum == PARTY_B) {
+  //   tmp_share[0] = bit_share[5];
+  // }
+  // FanInBitAdd(tmp_share, res, 1);
+  // B2A(res, tmp_c, 1);
+  // GetMpcOpInner(Reconstruct2PC)->Run(tmp_c, tmp_c.size(), "Final Equal temp res");
+  // tmp testing end!
+  FanInBitAdd(bit_share, res, size);
+  // GetMpcOpInner(ReconstructBit2PC)->Run(res, res.size(), "Debug BitAdd res");
+  B2A(res, c, size);
+  // GetMpcOpInner(Reconstruct2PC)->Run(c, c.size(), "Final Equal res");
+  return 0;
+}
+
+int Equal::FanInBitAdd(const vector<vector<small_mpc_t>>& a, vector<small_mpc_t>& c, size_t vec_size) {
+  // S0: check and init
+  //    the inner vector must have the same size 
+  // normally, the LEN should be sizeof(mpc_t) * 8
+  // cout << "FANInbitAdd size:" << a.size() << " of inner:" << a[0].size() << endl;
+  int LEN = a[0].size();
+  for (int i = 0; i < vec_size; ++i) {
+    assert(a[i].size() == LEN);
+  }
+
+  vector<vector<small_mpc_t>> all_bits = a;
+  int Depth = int(log2(LEN));
+  assert((1 << Depth) == LEN && "Only 2^i len is supported!");
+
+  vector<small_mpc_t> flat_a_vec;
+  vector<small_mpc_t> flat_b_vec;
+  int curr_len = LEN;
+  // This is just a tricky shortcut
+  auto ptr = std::make_shared<rosetta::snn::DotProduct>(msg_id(), io);
+  // this is binary-tree strategy to perform AND in parallel.
+  for(int i = 0; i < Depth; ++i) {
+    // cout << "depth:" << i << endl;
+    flat_a_vec.clear();
+    flat_b_vec.clear();
+    // flat matrix to vector
+    for (int k = 0; k < vec_size; ++k) {
+      for (int j = 0; j < curr_len -1; j=j+2) {
+        flat_a_vec.push_back(all_bits[k][j]);
+        flat_b_vec.push_back(all_bits[k][j+1]);
+      }
+    }
+    vector<small_mpc_t> flat_c_vec(flat_a_vec.size(),0);
+    ptr->BitMul(flat_a_vec, flat_b_vec, flat_c_vec, flat_a_vec.size());
+    // for debuging
+    // if(PRIMARY) {
+    //   GetMpcOpInner(ReconstructBit2PC)->Run(flat_a_vec, flat_a_vec.size(), "Debug Bit A");
+    //   GetMpcOpInner(ReconstructBit2PC)->Run(flat_b_vec, flat_b_vec.size(), "Debug Bit B");
+    //   GetMpcOpInner(ReconstructBit2PC)->Run(flat_c_vec, flat_c_vec.size(), "Debug Bit C");
+    // }
+
+    // reconstruct matrix from vector 
+    curr_len = curr_len / 2;
+    // cout << "new len:" << curr_len << endl;
+    for(int k = 0; k < vec_size; ++k) {
+      all_bits[k].clear();
+      all_bits[k].insert(all_bits[k].begin(), flat_c_vec.begin() + k * curr_len, flat_c_vec.begin() + (k+1) * curr_len);
+    }
+  }
+
+  for(int i = 0; i < vec_size; ++i) {
+    // make sure result is legal: all size should be 1! 
+    // cout << "check[" << i << "]:" << all_bits[i].size() << ":" << (all_bits[i][0] & 0x01) << std::endl; 
+    c[i] = all_bits[i][0] & 0x01;
+  }
+  return 0;
+}
+
+int Equal::B2A(const vector<small_mpc_t>& bit_shares, vector<mpc_t>& arith_shares, size_t size) {
+  vector<small_mpc_t> bit_m_0(size, 0);
+  vector<small_mpc_t> bit_m_1(size, 0);
+  vector<small_mpc_t> bit_m(size, 0);
+  vector<mpc_t> m_0(size, 0);
+  vector<mpc_t> m_1(size, 0);
+  vector<mpc_t> m(size, 0);
+
+  if (HELPER) {
+    populateRandomVector<small_mpc_t>(bit_m_0, size, "a_1", "POSITIVE");
+    populateRandomVector<mpc_t>(m_0, size, "a_1", "POSITIVE");
+    populateRandomVector<small_mpc_t>(bit_m_1, size, "a_2", "POSITIVE");
+    for (int i = 0; i < size; ++i) {
+      bit_m[i] = (bit_m_0[i] ^ bit_m_1[i]) & 0x01;
+      m_1[i] = (mpc_t)(bit_m[i] << FLOAT_PRECISION_M) - m_0[i];
+    }
+    sendVector<mpc_t>(m_1, PARTY_B, size);
+  }
+  if (partyNum == PARTY_A) {
+    populateRandomVector<small_mpc_t>(bit_m_0, size, "a_1", "POSITIVE");
+    populateRandomVector<mpc_t>(m_0, size, "a_1", "POSITIVE");
+    bit_m = bit_m_0;
+    m = m_0;
+  } 
+  if (partyNum == PARTY_B) {
+    populateRandomVector<small_mpc_t>(bit_m_1, size, "a_2", "POSITIVE");
+    bit_m = bit_m_1;
+    receiveVector<mpc_t>(m_1, PARTY_C, size);
+    m = m_1;
+  }
+
+  vector<small_mpc_t> masked_bit_shares(size, 0);
+  if (PRIMARY) {
+    for (int i = 0; i < size; ++i) {
+      masked_bit_shares[i] = bit_shares[i] ^ bit_m[i] & 0x01;
+    }
+    // reveal masked bit_shares
+    vector<small_mpc_t> other_part(size, 0);
+    vector<small_mpc_t> plain_bit(size, 0);
+    thread* exchange_threads = new thread[2];
+      exchange_threads[0] = thread(
+        &OpBase_::sendBitVector, this, ref(masked_bit_shares), adversary(partyNum), size);
+      exchange_threads[1] = thread(
+        &OpBase_::receiveBitVector, this, ref(other_part), adversary(partyNum), size);
+    exchange_threads[0].join();
+    exchange_threads[1].join();
+    delete[] exchange_threads;
+    
+    for (int i = 0; i < size; ++i) {
+      plain_bit[i] = (masked_bit_shares[i] ^ other_part[i]) & 0x01;
+      
+      if (plain_bit[i] == 0) {
+        arith_shares[i] = m[i];
+      } else {
+        if (partyNum == PARTY_A) {
+          arith_shares[i] = (1 << FLOAT_PRECISION_M) - m[i];
+        }
+        if (partyNum == PARTY_B) {
+          arith_shares[i] = -m[i];
+        }
+      }
+    }
+  }
+  return 0;
+}
+
 int NotEqual::funcNotEqual(const vector<mpc_t> &a, const vector<mpc_t> &b, vector<mpc_t> &c, size_t size)
 {
   if (validate_input(a, b, c, size) != 0)
@@ -106,6 +343,17 @@ int NotEqual::funcNotEqual(const vector<mpc_t> &a, const vector<mpc_t> &b, vecto
   return 0;
 }
 
+int NotEqual::funcFastNotEqual(const vector<mpc_t> &a, const vector<mpc_t> &b, vector<mpc_t> &c, size_t size)
+{
+  // Just (1 - Equal())
+  vector<mpc_t> CONST_ONE(size, 0);
+  if(partyNum == PARTY_A) {
+    CONST_ONE = vector<mpc_t>(size, 1 << FLOAT_PRECISION_M);
+  }
+  GetMpcOpInner(Equal)->Run(a, b, c, size);
+  subtractVectors<mpc_t>(CONST_ONE, c, c, size);
+  return 0;
+}
 
 int Greater::funcGreater(const vector<mpc_t> &a, const vector<mpc_t> &b, vector<mpc_t> &c, size_t size)
 {

--- a/cc/modules/protocol/mpc/snn/tests/snn_equal.cpp
+++ b/cc/modules/protocol/mpc/snn/tests/snn_equal.cpp
@@ -1,0 +1,53 @@
+#include "snn__test.h"
+#include <string>
+using namespace std;
+void run(int partyid) {
+  SNN_PROTOCOL_TEST_INIT(partyid);
+  //////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////
+
+  vector<double> X = {1.5, 0.31, -10.0, -0.02, -2, 19.0, 10.0};
+  vector<double> Y = {1.5, 0.01, -10.0, -0.21, 10, 10.0, 10.0};
+  vector<double> EQUAL_EXPECT = {1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+  vector<double> NEQUAL_EXPECT = {0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0};
+
+  size_t size = X.size();
+  print_vec(X, 10, "Input X");
+  print_vec(Y, 10, "Input Y");
+  
+  // Logger::Get().log_to_stdout(true);
+  // Logger::Get().set_filename("SNN_Equal_" + to_string(partyid) + ".log");
+  // Logger::Get().set_level(1);
+  string msgid("All basic Binary OP(s) (share,share)");
+  cout << __FUNCTION__ << " " << msgid << endl;
+  
+  vector<string> strX(X.size()), strY(X.size()), strZ(X.size());
+  snn0.GetOps(msgid)->PrivateInput(0, X, strX);
+  snn0.GetOps(msgid)->PrivateInput(1, Y, strY);
+  cout << __FUNCTION__ << " " << msgid << endl;  
+  vector<string> zZ(strZ.size());
+
+  ///// Utils test:  
+  // auto ptr = std::make_shared<rosetta::snn::DotProduct>(msgid, snn0.GetNetHandler());
+  // vector<small_mpc_t> a = {1, 1, 0, 0, 1};
+  // vector<small_mpc_t> b = {0, 1, 0, 1, 0};
+  // vector<small_mpc_t> c(a.size());
+
+  // ptr->BitMul(a, b, c, a.size());
+
+  snn0.GetOps(msgid)->Equal(strX, strY, strZ);
+  snn0.GetOps(msgid)->Reveal(strZ, zZ);
+  print_vec(zZ, 10, "SNN Equal plaintext:");
+  print_vec(EQUAL_EXPECT, 10, "Equal expected:");
+
+  snn0.GetOps(msgid)->NotEqual(strX, strY, strZ);
+  snn0.GetOps(msgid)->Reveal(strZ, zZ);
+  print_vec(zZ, 10, "SNN NotEqual plaintext:");
+  print_vec(NEQUAL_EXPECT, 10, "NotEqual expected:");
+
+  //////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////
+  SNN_PROTOCOL_TEST_UNINIT(partyid);
+}
+
+RUN_MPC_TEST(run);

--- a/compile_and_test_all.sh
+++ b/compile_and_test_all.sh
@@ -2,7 +2,6 @@
 # find . -name '*.sh' | xargs chmod 755
 # find . -name '*.py' | xargs chmod 755
 
-
 # This script for compiling all c++ projects and python-setup project
 # Also runing all tests
 
@@ -71,7 +70,7 @@ function run_all() {
     run_stage_1
     run_stage_2
     run_stage_3
-
+    
     echo -e "run 64bits binary all ok."
 }
 
@@ -88,7 +87,7 @@ function run_all_with_128() {
     run_stage_prepare ${build_type} ${use_128}
     run_stage_1
     run_stage_2
-
+    
     echo -e "run and compile 128 bits binaries ok."
 
     # build 128 _rosetta.xxxx.so and backup


### PR DESCRIPTION
* performance:
Before：
![image-20200929120308995](https://user-images.githubusercontent.com/3355765/94538169-414e9e80-0276-11eb-81af-67f3c7d39545.png)
After:
![image-20200929115935158](https://user-images.githubusercontent.com/3355765/94538253-5b887c80-0276-11eb-94d8-f6506b16ae3f.png)

* Notes:
The main ideal is to carry out the Equal-Op with masked shared random value. 
During the implementation, we use binary-tree strategy to parallel the FanInBitAdd, for example:
![image-20200929103315882](https://user-images.githubusercontent.com/3355765/94538429-9be7fa80-0276-11eb-95c8-0d0c7da7fec8.png)

Still, there seems to be room to improve this, and I will keep trying.
