### PR TITLE
Add Logic operations and speedup some backend Ops

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -46,7 +46,7 @@ bash compile_and_test_all.sh
 
 ## 使用示例
 
-这里我们用一个简单的多方联合执行 AI 中常见的矩阵乘法操作的 demo 示例来演示下 Rosetta 的基本用法。
+这里我们用一个简单的多方联合执行 AI 中常见的矩阵乘法操作的 [demo 示例](example/tutorials/code/rosetta_demo.py) 来演示下 Rosetta 的基本用法。
 
 在这个例子中，我们假设三个个体各自持有一个私有的矩阵数据，他们想在不泄露自己数据明文的前提下共同的计算出这三个矩阵的乘积。为了简便，我们称这三方分别为 P0，P1 和 P2。
 

--- a/cc/modules/common/include/utils/helper.h
+++ b/cc/modules/common/include/utils/helper.h
@@ -50,6 +50,8 @@ string to_readable_hex(const T& v) {
 string to_readable_dec(const uintlong& v);
 
 ////////////////////////////////////////////////
+void print_vector(vector<double>& vec, string msg, size_t print_size = 4, int precision = 3);
+////////////////////////////////////////////////
 void print_vec(const vector<uint8_t>& a, int length = -1, string msg = "");
 void print_vec(const vector<int>& a, int length = -1, string msg = "");
 void print_vec(const vector<uint64_t>& a, int length = -1, string msg = "");

--- a/cc/modules/common/src/utils/helper.cpp
+++ b/cc/modules/common/src/utils/helper.cpp
@@ -89,6 +89,83 @@ void print_vec(const vector<unsigned __int128>& a, int length, string msg) {
   cout << endl;
 }
 
+/*
+Helper function: Prints a vector of floating-point values.
+*/
+template <typename T>
+inline void print_vector_(vector<T> vec, string msg, size_t print_size = 4, int precision = 3) {
+  /*
+    Save the formatting information for cout.
+    */
+  std::ios old_fmt(nullptr);
+  old_fmt.copyfmt(cout);
+
+  size_t slot_count = vec.size();
+
+  cout << msg << ": size [" << vec.size() << "]" << endl;
+  cout << std::fixed << std::setprecision(precision);
+  //cout << endl;
+  if (slot_count <= 2 * print_size) {
+    cout << "  [";
+    for (size_t i = 0; i < slot_count; i++) {
+      cout << " " << vec[i] << ((i != slot_count - 1) ? "," : " ]\n");
+    }
+  } else {
+    vec.resize(std::max(vec.size(), 2 * print_size));
+    cout << "  [";
+    for (size_t i = 0; i < print_size; i++) {
+      cout << " " << vec[i] << ",";
+    }
+    if (vec.size() > 2 * print_size) {
+      cout << " ...,";
+    }
+    for (size_t i = slot_count - print_size; i < slot_count; i++) {
+      cout << " " << vec[i] << ((i != slot_count - 1) ? "," : " ]\n");
+    }
+  }
+  cout << endl;
+
+  /*
+    Restore the old cout formatting.
+    */
+  cout.copyfmt(old_fmt);
+}
+
+void print_vector(std::vector<double>& vec, std::string msg, size_t print_size, int precision) {
+  print_vector_(vec, msg, print_size, precision);
+}
+
+/*
+Helper function: Prints a matrix of values.
+*/
+template <typename T>
+inline void print_matrix(vector<T> matrix, size_t row_size) {
+  /*
+    We're not going to print every column of the matrix (there are 2048). Instead
+    print this many slots from beginning and end of the matrix.
+    */
+  size_t print_size = 5;
+
+  cout << endl;
+  cout << "    [";
+  for (size_t i = 0; i < print_size; i++) {
+    cout << setw(3) << std::right << matrix[i] << ",";
+  }
+  cout << setw(3) << " ...,";
+  for (size_t i = row_size - print_size; i < row_size; i++) {
+    cout << setw(3) << matrix[i] << ((i != row_size - 1) ? "," : " ]\n");
+  }
+  cout << "    [";
+  for (size_t i = row_size; i < row_size + print_size; i++) {
+    cout << setw(3) << matrix[i] << ",";
+  }
+  cout << setw(3) << " ...,";
+  for (size_t i = 2 * row_size - print_size; i < 2 * row_size; i++) {
+    cout << setw(3) << matrix[i] << ((i != 2 * row_size - 1) ? "," : " ]\n");
+  }
+  cout << endl;
+};
+
 void print_vec(const vector<double>& a, int length, string msg) {
   if (length < 0 || length > a.size())
     length = a.size();

--- a/cc/modules/protocol/mpc/comm/include/mpc_helper.h
+++ b/cc/modules/protocol/mpc/comm/include/mpc_helper.h
@@ -27,4 +27,6 @@ void convert_double_to_mpctype(const vector<double>& a, vector<mpc_t>& b);
 
 void convert_string_to_mpctype(const vector<std::string>& a, vector<mpc_t>& b, bool human = true);
 void convert_mpctype_to_string(const vector<mpc_t>& a, vector<std::string>& b, bool human = true);
+
+vector<int> get_mpc_peers(int party);
 // clang-format on

--- a/cc/modules/protocol/mpc/comm/include/mpc_protocol.h
+++ b/cc/modules/protocol/mpc/comm/include/mpc_protocol.h
@@ -57,7 +57,7 @@ class MpcProtocol : public ProtocolBase {
   virtual int _init_aeskeys();
 
   //! @attention! now, only for snn, will remove in the future
-  virtual void _initialize_mpc_enviroment() {}
+  virtual void _initialize_mpc_environment() {}
 
  protected:
   std::shared_ptr<MpcPRG> gseed = nullptr; // for global random seed

--- a/cc/modules/protocol/mpc/comm/src/mpc_protocol.cpp
+++ b/cc/modules/protocol/mpc/comm/src/mpc_protocol.cpp
@@ -35,7 +35,7 @@ int MpcProtocol::Init(std::string config_json_str) {
       _init_config(config_json_str);
       my_party_id = config->PARTY;
       config->fmt_print();
-      _initialize_mpc_enviroment();
+      _initialize_mpc_environment();
       _init_with_config();
       _init_aeskeys();
       _is_inited = true;
@@ -62,7 +62,7 @@ int MpcProtocol::Init(int partyid, string config_json_str, string logfile) {
       _init_config(partyid, config_json_str);
       my_party_id = config->PARTY;
       config->fmt_print();
-      _initialize_mpc_enviroment();
+      _initialize_mpc_environment();
       _init_with_config();
       _init_aeskeys();
       _is_inited = true;

--- a/cc/modules/protocol/mpc/comm/src/mpc_util.cpp
+++ b/cc/modules/protocol/mpc/comm/src/mpc_util.cpp
@@ -107,3 +107,25 @@ void convert_mpctype_to_string(const vector<mpc_t>& a, vector<std::string>& b, b
     }
   }
 }
+
+
+/**
+ * get_mpc_peers
+ */
+vector<int> get_mpc_peers(int party) {
+  static vector<int> mpc_a_peers{PARTY_B, PARTY_C};
+  static vector<int> mpc_b_peers{PARTY_A, PARTY_C};
+  static vector<int> mpc_c_peers{PARTY_B, PARTY_A};
+  
+  switch (party)
+  {
+  case PARTY_A:
+    return mpc_a_peers;
+  case PARTY_B:
+    return mpc_b_peers;
+  case PARTY_C:
+    return mpc_c_peers;
+  default:
+    throw std::runtime_error(string("party id invalid"));
+  }
+}

--- a/cc/modules/protocol/mpc/snn/include/opsets_local.h
+++ b/cc/modules/protocol/mpc/snn/include/opsets_local.h
@@ -28,6 +28,7 @@ namespace rosetta {
 namespace snn {
 // clang-format off
 void funcTruncate2PC(vector<mpc_t> &a, size_t power, size_t size, size_t party_1, size_t party_2);
+void funcTruncate2PC_many(vector<mpc_t>& a, vector<size_t> power, size_t size, size_t party_1, size_t party_2);
 void funcTruncateElem2PC(mpc_t &a, size_t power, size_t party_1, size_t party_2);
 mpc_t funcTruncateElem2PCConst(const mpc_t &a, size_t power = FLOAT_PRECISION_M, size_t party_1 = PARTY_A, size_t party_2 = PARTY_B);
 void funcXORModuloOdd2PC(vector<small_mpc_t> &bit, vector<mpc_t> &shares, vector<mpc_t> &output, size_t size);

--- a/cc/modules/protocol/mpc/snn/include/opsets_nn.h
+++ b/cc/modules/protocol/mpc/snn/include/opsets_nn.h
@@ -33,7 +33,7 @@ public:
             const vector<mpc_t>& shared_labels,
             vector<mpc_t>& shared_result,
             size_t vec_size) {
-            MPCOP_RETURN(sigmoid_cross_entropy(shared_logits, 
+            MPCOP_RETURN(sigmoid_cross_entropy_batch(shared_logits, 
                                                 shared_labels, 
                                                 shared_result, vec_size));
         }
@@ -47,6 +47,17 @@ public:
         }
 
     /**
+     * @Note: Speedup in low-bandthwith network environment, with less communication round.
+     * 
+     */
+    int sigmoid_cross_entropy_batch(const vector<mpc_t>& shared_logits,
+            const vector<mpc_t>& shared_labels,
+            vector<mpc_t>& shared_result,
+            size_t vec_size);
+
+
+    /**
+     * Obsoleted, please use the faster one, sigmoid_cross_entropy_batch
         @Note: Just like the 'sigmoid_cross_entropy_with_logits' in python/ops/nn_impl.py of
             original Tensorflow source code, we implement formulation:
             max(logit, 0) - logit * label + log(1 + exp(-abs(x)))

--- a/cc/modules/protocol/mpc/snn/include/snn_opsets.h
+++ b/cc/modules/protocol/mpc/snn/include/snn_opsets.h
@@ -162,15 +162,9 @@ namespace snn {
 
 class OpBase : public OpBase_ {
  public:
-  explicit OpBase(const msg_id_t& key) : msg_id_(key) {
-    init();
-  }
-  explicit OpBase(const std::string& key) : msg_id_(key) {
-    init();
-  }
-  explicit OpBase(const std::shared_ptr<OpBase>& op) : msg_id_(op->msg_id()) {
-    init();
-  }
+  explicit OpBase(const msg_id_t& key) : msg_id_(key) { init(); }
+  explicit OpBase(const std::string& key) : msg_id_(key) { init(); }
+  explicit OpBase(const std::shared_ptr<OpBase>& op) : msg_id_(op->msg_id()) { init(); }
 
   explicit OpBase(const msg_id_t& key, shared_ptr<NET_IO> io__) : msg_id_(key) {
     io = io__;
@@ -189,9 +183,7 @@ class OpBase : public OpBase_ {
   virtual ~OpBase() = default;
 
  public:
-  virtual const msg_id_t& msg_id() const {
-    return msg_id_;
-  }
+  virtual const msg_id_t& msg_id() const { return msg_id_; }
 
  protected:
   msg_id_t msg_id_;
@@ -210,9 +202,7 @@ class Synchronize : public OpBase {
   using OpBase::OpBase;
 
  public:
-  int Run() {
-    MPCOP_RETURN(funcSynchronize());
-  }
+  int Run() { MPCOP_RETURN(funcSynchronize()); }
 
  private:
   int funcSynchronize();
@@ -236,9 +226,7 @@ class RandomSeed : public OpBase {
   using OpBase::OpBase;
 
  public:
-  int Run(mpc_t& seed) {
-    MPCOP_RETURN(funcRandomSeed(seed));
-  }
+  int Run(mpc_t& seed) { MPCOP_RETURN(funcRandomSeed(seed)); }
 
  private:
   int funcRandomSeed(mpc_t& seed) {
@@ -260,12 +248,8 @@ class PRZS : public OpBase {
   int Run(int party0, int party1, vector<double>& shares) {
     MPCOP_RETURN(funPRZS(party0, party1, shares));
   }
-  int Run(int party0, int party1, mpc_t& shares) {
-    MPCOP_RETURN(funPRZS(party0, party1, shares));
-  }
-  int Run(int party0, int party1, double& shares) {
-    MPCOP_RETURN(funPRZS(party0, party1, shares));
-  }
+  int Run(int party0, int party1, mpc_t& shares) { MPCOP_RETURN(funPRZS(party0, party1, shares)); }
+  int Run(int party0, int party1, double& shares) { MPCOP_RETURN(funPRZS(party0, party1, shares)); }
 
  private:
   int funPRZS(int party0, int party1, vector<mpc_t>& shares);
@@ -304,12 +288,8 @@ class PrivateInput : public OpBase {
   int Run(int party, const vector<double>& v, vector<double>& shares) {
     MPCOP_RETURN(funPrivateInput(party, v, shares));
   }
-  int Run(int party, double v, mpc_t& shares) {
-    MPCOP_RETURN(funPrivateInput(party, v, shares));
-  }
-  int Run(int party, double v, double& shares) {
-    MPCOP_RETURN(funPrivateInput(party, v, shares));
-  }
+  int Run(int party, double v, mpc_t& shares) { MPCOP_RETURN(funPrivateInput(party, v, shares)); }
+  int Run(int party, double v, double& shares) { MPCOP_RETURN(funPrivateInput(party, v, shares)); }
 
  private:
   int funPrivateInput(int party, const vector<double>& v, vector<mpc_t>& shares);
@@ -332,6 +312,23 @@ class PrivateInput : public OpBase {
     shares = MpcTypeToFloat(ss);
     return 0;
   }
+};
+
+/**
+ * broadcast public values to peers
+ * now, only supports P0 or P1
+ * now, only supports double as input(s)
+ */
+class Broadcast : public OpBase {
+  using OpBase::OpBase;
+
+ public:
+  int Run(int party, const string& msg, string& result) {
+    MPCOP_RETURN(funcBroadcast(party, msg, result));
+  }
+
+ private:
+  int funcBroadcast(int party, const string& msg, string& result);
 };
 
 /*
@@ -465,9 +462,7 @@ class ReluPrime : public OpBase {
   int Run3PC(const vector<mpc_t>& a, vector<mpc_t>& b, size_t size) {
     MPCOP_RETURN(funcRELUPrime3PC(a, b, size));
   }
-  int Run(const vector<mpc_t>& a, vector<mpc_t>& b, size_t size) {
-    return Run3PC(a, b, size);
-  }
+  int Run(const vector<mpc_t>& a, vector<mpc_t>& b, size_t size) { return Run3PC(a, b, size); }
 
  private:
   int funcRELUPrime3PC(const vector<mpc_t>& a, vector<mpc_t>& b, size_t size);
@@ -480,7 +475,7 @@ class Min : public OpBase {
   int Run(const vector<mpc_t>& a, vector<mpc_t>& minv, size_t rows, size_t columns) {
     vector<mpc_t> minIndex(rows);
     minv.resize(rows);
-    MPCOP_RETURN(funcMinMPC(a, minv, minIndex, rows, columns));
+    MPCOP_RETURN(funcMinMPC(a, minv, minIndex, rows, columns, false));
   }
 
  private:
@@ -489,7 +484,8 @@ class Min : public OpBase {
     vector<mpc_t>& minv,
     vector<mpc_t>& minIndex,
     size_t rows,
-    size_t columns);
+    size_t columns,
+    bool need_index = true);
 };
 
 class MinIndex : public OpBase {
@@ -510,8 +506,11 @@ class Max : public OpBase {
  public:
   int Run(const vector<mpc_t>& a, vector<mpc_t>& maxv, size_t rows, size_t cols) {
     vector<mpc_t> maxIndex;
-    return Run(a, maxv, maxIndex, rows, cols);
+    maxv.resize(rows);
+    // no need to get maxIndex, 'maxIndex' is just a adapted placeholder.
+    MPCOP_RETURN(funcMaxMPC(a, maxv, maxIndex, rows, cols, false));
   }
+
 
   int Run(
     const vector<mpc_t>& a,
@@ -530,7 +529,8 @@ class Max : public OpBase {
     vector<mpc_t>& maxv,
     vector<mpc_t>& maxIndex,
     size_t rows,
-    size_t cols);
+    size_t cols,
+    bool need_index = true);
 };
 class MaxIndex : public OpBase {
   using OpBase::OpBase;
@@ -637,7 +637,11 @@ class Reconstruct2PC : public OpBase {
   }
   int funcReconstruct2PC(const vector<mpc_t>& a, size_t size, string str);
   int funcReconstruct2PC(const vector<mpc_t>& a, size_t size, vector<mpc_t>& out, int recv_party);
-  int funcReconstruct2PC_ex(const vector<mpc_t>& a, size_t size, vector<mpc_t>& out, int recv_party);
+  int funcReconstruct2PC_ex(
+    const vector<mpc_t>& a,
+    size_t size,
+    vector<mpc_t>& out,
+    int recv_party);
 
   /**
    * @brief: the shared_v will be 'revealed' to plaintext_v held by rev_party 
@@ -663,7 +667,7 @@ class ReconstructBit2PC : public OpBase {
 
 /*
   @note: this Polynomial is mostly for internal usage, 
-    especially for complex funtionalities, such as Log and Log1p, that 
+    especially for complex functionalities, such as Log and Log1p, that 
     are implemented with polynomial interpolation.
   
   @attention: for now DO NOT use this directly if you are not sure.
@@ -680,22 +684,13 @@ class Polynomial : public OpBase {
 		[in] common_k, power value.
 		[out] shared_Y, the resulting value.
 		[in] curr_cache, the auxiliary cache,
-			 containing some computed k --> Y, to acclerate.
+			 containing some computed k --> Y, to accelerate.
   */
-  void mpc_pow_const(
-    const mpc_t& shared_X,
-    mpc_t common_k,
-    mpc_t& shared_Y);
+  void mpc_pow_const(const mpc_t& shared_X, mpc_t common_k, mpc_t& shared_Y);
 
-  void mpc_pow_const(
-    const vector<mpc_t>& shared_X,
-    mpc_t common_k,
-    vector<mpc_t>& shared_Y);
+  void mpc_pow_const(const vector<mpc_t>& shared_X, mpc_t common_k, vector<mpc_t>& shared_Y);
 
-  void local_const_mul(
-    const vector<mpc_t>& shared_X,
-    mpc_t common_V,
-    vector<mpc_t>& shared_Y);
+  void local_const_mul(const vector<mpc_t>& shared_X, mpc_t common_V, vector<mpc_t>& shared_Y);
 
   /*
 	  @brief: secret-shared version for computing a univariate polynomial:
@@ -715,10 +710,11 @@ class Polynomial : public OpBase {
     const vector<mpc_t>& common_coff_list,
     mpc_t& shared_Y);
 
-  void mpc_uni_polynomial(const vector<mpc_t>& shared_X, 
-		const vector<mpc_t>& common_power_list,
-		const vector<mpc_t>& common_coff_list,
-		vector<mpc_t>& shared_Y);
+  void mpc_uni_polynomial(
+    const vector<mpc_t>& shared_X,
+    const vector<mpc_t>& common_power_list,
+    const vector<mpc_t>& common_coff_list,
+    vector<mpc_t>& shared_Y);
 };
 
 class PrivateCompare : public OpBase {
@@ -749,9 +745,7 @@ class ShareConvert : public OpBase {
   using OpBase::OpBase;
 
  public:
-  int Run(vector<mpc_t>& a, size_t size) {
-    MPCOP_RETURN(funcShareConvertMPC(a, size));
-  }
+  int Run(vector<mpc_t>& a, size_t size) { MPCOP_RETURN(funcShareConvertMPC(a, size)); }
 
  private:
   int funcShareConvertMPC(vector<mpc_t>& a, size_t size);
@@ -764,9 +758,7 @@ class ComputeMSB : public OpBase {
   int Run3PC(const vector<mpc_t>& a, vector<mpc_t>& b, size_t size) {
     MPCOP_RETURN(funcComputeMSB3PC(a, b, size));
   }
-  int Run(const vector<mpc_t>& a, vector<mpc_t>& b, size_t size) {
-    return Run3PC(a, b, size);
-  }
+  int Run(const vector<mpc_t>& a, vector<mpc_t>& b, size_t size) { return Run3PC(a, b, size); }
 
  private:
   // only 3PC, not cope 4PC
@@ -815,14 +807,14 @@ class Sigmoid : public OpBase {
   int RunChebyshevPoly(const vector<mpc_t>& a, vector<mpc_t>& b, size_t size) {
     MPCOP_RETURN(funcSigmoidChebyshevPolyMPC(a, b, size));
   }
-  
+
   int Run(const vector<mpc_t>& a, vector<mpc_t>& b, size_t size) {
 #define USE_SIGMOID_VERSION 1
 #if USE_SIGMOID_VERSION == 0
     return RunChebyshevPoly(a, b, size);
 #elif USE_SIGMOID_VERSION == 1
-    return Run3PieceWise(a, b, size);
-#elif USE_SIGMOID_VERSION == 2 //USE_PIECE_WISE_SIGMOID
+    return Run3PieceWise(a, b, size); // 3-segments
+#elif USE_SIGMOID_VERSION == 2 // 6-segments
     return RunPieceWise(a, b, size);
 #else
     return RunG3(a, b, size);
@@ -870,9 +862,7 @@ class BinaryOp : public OpBase {
 
  public:
   virtual ~BinaryOp() = default;
-  int Run(const mpc_t& a, const mpc_t& b, mpc_t& c) {
-    MPCOP_RETURN(funcBinaryOp(a, b, c));
-  }
+  int Run(const mpc_t& a, const mpc_t& b, mpc_t& c) { MPCOP_RETURN(funcBinaryOp(a, b, c)); }
   int Run(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size) {
     c.resize(size);
     MPCOP_RETURN(funcBinaryOp(a, b, c, size));
@@ -1047,9 +1037,13 @@ class DotProduct : public BinaryOp {
     return funcBinaryOp(b, a, c, size);
   }
 
-public:
+ public:
   // this is actually the AND functionality for bit-share.
-  int BitMul(const vector<small_mpc_t>& a, const vector<small_mpc_t>& b, vector<small_mpc_t> & c, size_t size);
+  int BitMul(
+    const vector<small_mpc_t>& a,
+    const vector<small_mpc_t>& b,
+    vector<small_mpc_t>& c,
+    size_t size);
 
  private:
   int funcDotProduct(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size);
@@ -1087,18 +1081,11 @@ class DivBase : public BinaryOp {
     vector<mpc_t>& c,
     size_t size) {
     c.resize(size);
-    // locally compute c = fa * (1/b)
-    {
-      vector<mpc_t> a(b.size(), FloatToMpcType(0.5));
-      funcBinaryOp(a, b, c, size);
-    }
     vector<mpc_t> a(fa.size(), 0);
-    convert_double_to_mpctype(fa, a);
-    for (size_t i = 0; i < size; i++) {
-      c[i] = a[i] * c[i];
+    if (partyNum == PARTY_A) {
+      convert_double_to_mpctype(fa, a);
     }
-    if (PRIMARY)
-      funcTruncate2PC(c, FLOAT_PRECISION_M, size, PARTY_A, PARTY_B);
+    funcBinaryOp(a, b, c, size);
     return 0;
   }
   //[kelvin] NOTE: string represents const
@@ -1108,22 +1095,13 @@ class DivBase : public BinaryOp {
     vector<mpc_t>& c,
     size_t size) {
     c.resize(size);
-    // locally compute c = sa * (1/b)
-    {
-      vector<mpc_t> a(b.size(), FloatToMpcType(0.5));
-      funcBinaryOp(a, b, c, size);
-    }
-
     vector<double> da(sa.size());
     vector<mpc_t> a(sa.size(), 0);
     rosetta::convert::from_double_str(sa, da);
-    convert_double_to_mpctype(da, a);
-
-    for (size_t i = 0; i < size; i++) {
-      c[i] = a[i] * c[i];
+    if (partyNum == PARTY_A) {
+      convert_double_to_mpctype(da, a);
     }
-    if (PRIMARY)
-      funcTruncate2PC(c, FLOAT_PRECISION_M, size, PARTY_A, PARTY_B);
+    funcBinaryOp(a, b, c, size);
     return 0;
   }
 
@@ -1135,38 +1113,26 @@ class DivBase : public BinaryOp {
     // std::cout << "debug stub DIV SC" << endl;
     // locally compute c = a * (1/fb)
     vector<double> tb(fb.size(), 0);
-    vector<int> tmp_shift(size, 0);
+    vector<size_t> power_list(size, FLOAT_PRECISION_M);
     for (size_t i = 0; i < size; i++) {
       tb[i] = 1.0 / fb[i];
       // This is for dealing with big constant denominator, part I:
-        //  scale it up by left-shifting
-        double abs_v = abs(fb[i]);
-        if(abs_v > 1) {
-            tmp_shift[i] = ceil(log2(abs_v));
-            tb[i] = tb[i] * (1 << tmp_shift[i]);
-        }
-        // std::cout << "SNN::Div " << fb[i] << " -> " << tb[i] << 
-        //        " [" << tmp_shift[i] << "]" << endl;       
-
+      //  scale it up by left-shifting
+      double abs_v = abs(fb[i]);
+      if (abs_v > 1) {
+        power_list[i] = ceil(log2(abs_v));
+        tb[i] = tb[i] * (1 << power_list[i]);
+        power_list[i] = power_list[i] + FLOAT_PRECISION_M;
+      }
     }
     vector<mpc_t> b(tb.size(), 0);
     convert_double_to_mpctype(tb, b);
-    c.resize(a.size());
-    for (size_t i = 0; i < size; i++) {
+    c.resize(size);
+    for (size_t i = 0; i < size; ++i) {
       c[i] = a[i] * b[i];
     }
-
-    if (PRIMARY)
-      funcTruncate2PC(c, FLOAT_PRECISION_M, size, PARTY_A, PARTY_B);
-    // TODO:vectorization
-    // This is for dealing with big constant denominator, part II:
-    //  trunc it back in the final result
-    vector<mpc_t> single_share(1);
-    for(auto i = 0; i < size; ++i) {
-        single_share[0] = c[i];
-        if (PRIMARY)
-          funcTruncate2PC(single_share, tmp_shift[i], 1, PARTY_A, PARTY_B);
-        c[i] = single_share[0];
+    if (PRIMARY) {
+      funcTruncate2PC_many(c, power_list, size, PARTY_A, PARTY_B);
     }
     return 0;
   }
@@ -1181,7 +1147,6 @@ class DivBase : public BinaryOp {
     // b to 1/b, div replace with mul
     vector<double> db(sb.size());
     rosetta::convert::from_double_str(sb, db);
-    vector<int> tmp_shift(size, 0);
     return funcBinaryOp(a, db, c, size);
   }
   //   for (size_t i = 0; i < size; i++) {
@@ -1275,14 +1240,14 @@ class Pow : public OpBase {
 
     // Added in V0.2.1 to support vectorization
     bool is_common_k = true;
-    for(int i = 1; i < size; ++i) {
-      if(n[i] != n[i-1]) {
+    for (int i = 1; i < size; ++i) {
+      if (n[i] != n[i - 1]) {
         is_common_k = false;
         break;
       }
     }
 
-    if(is_common_k) {
+    if (is_common_k) {
       // cout << "DEBUG; common k" << endl;
       poly->mpc_pow_const(x, n[0], y);
       return 0;
@@ -1322,7 +1287,7 @@ class Log : public OpBase {
   }
 
   /*
-  	@brief: General high precision approximation(gurantee four decimal part)
+  	@brief: General high precision approximation(guarantee four decimal part)
   			for LOG in the domain
   */
   int mpc_log_hd(const vector<mpc_t>& shared_X, vector<mpc_t>& shared_Y, size_t vec_size);
@@ -1366,16 +1331,16 @@ class Log : public OpBase {
   }
   /*
     obsolete!
-	  @brief: secret-sahred version of logarithm with one-segment polynomial
+	  @brief: secret-shared version of logarithm with one-segment polynomial
 	  with domain x \in [0.3, 1.8)
   */
   void mpc_log_v1(const mpc_t& shared_X, mpc_t& shared_Y);
 
   /*
-  	@brief: secret-sahred version of logarithm with three-segment polynomial
+  	@brief: secret-shared version of logarithm with three-segment polynomial
   */
   void mpc_log_v2(const mpc_t& shared_X, mpc_t& shared_Y);
-  
+
   void mpc_log_v2(const vector<mpc_t>& shared_X, vector<mpc_t>& shared_Y);
 };
 
@@ -1387,9 +1352,7 @@ class CompareOp : public OpBase {
     c.resize(a.size());
     MPCOP_RETURN(RunCompareOp(a, b, c, size));
   }
-  int Run(const mpc_t& a, const mpc_t& b, mpc_t& c) {
-    MPCOP_RETURN(RunCompareOp(a, b, c));
-  }
+  int Run(const mpc_t& a, const mpc_t& b, mpc_t& c) { MPCOP_RETURN(RunCompareOp(a, b, c)); }
 
   // const OP, in P0, c = a (op) b; in P1, c = 0 (op) b
   int Run(const vector<double>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size) {
@@ -1490,17 +1453,15 @@ class Equal : public CompareOp {
     return funcFastEqual(a, b, c, size);
   }
 
-// temp make these as public funcs
-public:
+  // temp make these as public funcs
+ public:
   // retired! NOT use this any more.
   int funcEqual(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size);
   // Optimized version, default one.
   int funcFastEqual(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size);
-  
+
   // for each a_i in a, get a_i[0] AND a_i[1] AND a_i[2] ... AND a_i[n] as c[i]
-  int FanInBitAdd(const vector<vector<small_mpc_t>>& a,
-                  vector<small_mpc_t>& c,
-                  size_t size);
+  int FanInBitAdd(const vector<vector<small_mpc_t>>& a, vector<small_mpc_t>& c, size_t size);
   // convert binary bit-share to arithematic share of the same plain value.
   int B2A(const vector<small_mpc_t>& bit_shares, vector<mpc_t>& arith_shares, size_t size);
 };
@@ -1517,11 +1478,15 @@ class NotEqual : public CompareOp {
     return funcFastNotEqual(a, b, c, size);
   }
 
-private:
+ private:
   // retired! NOT use this any more.
   int funcNotEqual(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size);
-    // Optimized version, default one.
-  int funcFastNotEqual(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size);
+  // Optimized version, default one.
+  int funcFastNotEqual(
+    const vector<mpc_t>& a,
+    const vector<mpc_t>& b,
+    vector<mpc_t>& c,
+    size_t size);
 };
 
 class Less : public CompareOp {
@@ -1536,7 +1501,7 @@ class Less : public CompareOp {
     return funcLess(a, b, c, size);
   }
 
-private:
+ private:
   int funcLess(const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size);
 };
 
@@ -1676,12 +1641,12 @@ class XorBit : public OpBase {
 		[in] common_vec_size[plaintext]: the size of the input vectors.
 		[in] common_all_less[plaintext]:  
 				bool value to indicate whether all numerators are less than
-				its corresponding denomimators.
-				This is for efficency in this special case.
+				its corresponding denominators.
+				This is for efficiency in this special case.
 		[out] shared_quotient_vec: the resulting vector of quotients
 	@note:
 		This function supports both x>=y and x<y; 
-		and both positiveness negetiveness.
+		and both positiveness negativeness.
 		And if x is not divisable by y,
 		the precision of the fractional part is FLOAT_PRECISION_M.
   @author: SJJ
@@ -1765,7 +1730,7 @@ class FloorDivision : public OpBase {
     vector<mpc_t>& c,
     size_t size,
     bool all_positive = false) {
-    // not like the ture division, the local speedup may cause 0. So we use ordinary convention here.
+    // not like the true division, the local speedup may cause 0. So we use ordinary convention here.
     vector<double> da(sa.size());
     rosetta::convert::from_double_str(sa, da);
     // split it even in two parties so the sum (real value) is still the sa value.
@@ -1785,11 +1750,21 @@ class FloorDivision : public OpBase {
     vector<mpc_t>& c,
     size_t size,
     bool all_positive = false) {
-    // locally compute c = int(a * double(1/fb) )
     vector<double> db(sb.size());
     rosetta::convert::from_double_str(sb, db);
+    vector<size_t> power_list(size, FLOAT_PRECISION_M);
     for (size_t i = 0; i < size; ++i) {
+      // This is for dealing with big constant denominator, part I:
+      //  scale it up by left-shifting
+      double abs_v = abs(db[i]);
       db[i] = 1.0 / db[i];
+      
+      if(abs_v > 1) {
+          power_list[i] = ceil(log2(abs_v));
+          db[i] = db[i] * (1 << power_list[i]);
+          power_list[i] = power_list[i] + FLOAT_PRECISION_M;
+          // cout << "power_list: " << sb[i] << "->:" << db[i] << ", " << power_list[i] << endl;
+      }
     }
     vector<mpc_t> b(sb.size(), 0);
     convert_double_to_mpctype(db, b);
@@ -1799,7 +1774,7 @@ class FloorDivision : public OpBase {
       c[i] = a[i] * b[i];
     }
     if (PRIMARY) {
-      funcTruncate2PC(c, FLOAT_PRECISION_M, size, PARTY_A, PARTY_B);
+      funcTruncate2PC_many(c, power_list, size, PARTY_A, PARTY_B);
     }
     // set the float part as 0.
     if (PRIMARY) {
@@ -1838,6 +1813,123 @@ class FracDivision : public OpBase {
     vector<mpc_t>& shared_quotient_vec,
     size_t common_vec_size,
     bool all_positive = false);
+};
+
+/**
+ * Logical Operations, all the inputs/outputs have scaled, 
+ * the real value of all the inputs must be 1/0, or the result is unexpected!
+ * 
+ * @note we can derive from BinaryOp, but maybe some specials for logical ops in the future.
+ */
+class LogicalOp : public OpBase {
+  using OpBase::OpBase;
+
+ public:
+  virtual ~LogicalOp() = default;
+  int Run(const vector<mpc_t> a, const vector<mpc_t> b, vector<mpc_t>& c, size_t size) {
+    MPCOP_RETURN(funcLogicalOp(a, b, c, size));
+  }
+  int Run(const vector<mpc_t> a, const vector<string> b, vector<mpc_t>& c, size_t size) {
+    MPCOP_RETURN(funcLogicalOp(a, b, c, size));
+  }
+  int Run(const vector<string> a, const vector<mpc_t> b, vector<mpc_t>& c, size_t size) {
+    MPCOP_RETURN(funcLogicalOp(a, b, c, size));
+  }
+
+  int Run(const vector<vector<mpc_t>> shared_x, vector<mpc_t>& shared_result) {
+    MPCOP_RETURN(funcLogicalOp(shared_x, shared_result));
+  }
+
+ protected:
+  /**
+   * AND (x and y) = x*y
+   * OR  (x or y)  = x + y - x*y
+   * XOR (x xor y) = x + y - 2*x*y
+   * NOT (not x)   = 1 - x
+   * Z[i] = X[i] (OP) Y[i]
+   */
+  virtual int funcLogicalOp(
+    const vector<mpc_t> X,
+    const vector<mpc_t> Y,
+    vector<mpc_t>& Z,
+    size_t size) = 0;
+  virtual int funcLogicalOp(
+    const vector<mpc_t> X,
+    const vector<string> sY,
+    vector<mpc_t>& Z,
+    size_t size) {
+    Z.resize(size);
+    vector<double> dY(size, 0);
+    vector<mpc_t> Y(size, 0);
+    rosetta::convert::from_double_str(sY, dY);
+    convert_double_to_mpctype(dY, Y);
+
+    ///////////////////////////////////
+    for (size_t i = 0; i < size; i++) {
+      Z[i] = X[i] * Y[i];
+    }
+    if (PRIMARY)
+      funcTruncate2PC(Z, FLOAT_PRECISION_M, size, PARTY_A, PARTY_B);
+    ///////////////////////////////////
+    return 0;
+  }
+
+  virtual int funcLogicalOp(
+    const vector<string> X,
+    const vector<mpc_t> Y,
+    vector<mpc_t>& Z,
+    size_t size) {
+    return funcLogicalOp(Y, X, Z, size);
+  }
+  /**
+   * K-*, recursion version
+   * 
+   * XX is a 2-d vector
+   * if XX.size() == 0; return 0
+   * if XX.size() == 1; return XX[0]
+   * if XX.size() >= 1; return XX[0] (OP) XX[1] (OP)... XX[i]
+   */
+  int funcLogicalOp(const vector<vector<mpc_t>> XX, vector<mpc_t>& Z) {
+    return funcLogicalOp_(XX, Z);
+  };
+  int funcLogicalOp_(const vector<vector<mpc_t>> XX, vector<mpc_t>& Z);
+};
+
+class LogicalAND : public LogicalOp {
+  using LogicalOp::LogicalOp;
+
+ private:
+  int funcLogicalOp(const vector<mpc_t> X, const vector<mpc_t> Y, vector<mpc_t>& Z, size_t size);
+  int funcLogicalOp(const vector<mpc_t> X, const vector<string> sY, vector<mpc_t>& Z, size_t size);
+};
+
+class LogicalOR : public LogicalOp {
+  using LogicalOp::LogicalOp;
+
+ private:
+  int funcLogicalOp(const vector<mpc_t> X, const vector<mpc_t> Y, vector<mpc_t>& Z, size_t size);
+  int funcLogicalOp(const vector<mpc_t> X, const vector<string> sY, vector<mpc_t>& Z, size_t size);
+};
+
+class LogicalXOR : public LogicalOp {
+  using LogicalOp::LogicalOp;
+
+ private:
+  int funcLogicalOp(const vector<mpc_t> X, const vector<mpc_t> Y, vector<mpc_t>& Z, size_t size);
+  int funcLogicalOp(const vector<mpc_t> X, const vector<string> sY, vector<mpc_t>& Z, size_t size);
+};
+
+class LogicalNOT : public OpBase {
+  using OpBase::OpBase;
+
+ public:
+  int Run(const vector<mpc_t> X, vector<mpc_t>& Z, size_t size) {
+    Z.resize(size);
+    MPCOP_RETURN(funcLogicalOp(X, Z, size));
+  }
+
+ private:
+  int funcLogicalOp(const vector<mpc_t> X, vector<mpc_t>& Z, size_t size);
 };
 
 } // namespace snn

--- a/cc/modules/protocol/mpc/snn/src/impl/broadcast.cpp
+++ b/cc/modules/protocol/mpc/snn/src/impl/broadcast.cpp
@@ -15,21 +15,31 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the Rosetta library. If not, see <http://www.gnu.org/licenses/>.
 // ==============================================================================
-#pragma once
-#include "cc/modules/protocol/mpc/comm/include/mpc_protocol.h"
+#include "cc/modules/protocol/mpc/snn/src/impl/op_impl.h"
+#include <stdexcept>
 
+// this will remvoe to rtt/
 namespace rosetta {
-class SnnProtocol : public MpcProtocol {
- public:
-  SnnProtocol() : MpcProtocol("SecureNN") {}
+namespace snn {
 
- public:
-  shared_ptr<ProtocolOps> GetOps(const string& op_token = "");
-  
+int Broadcast::funcBroadcast(int from_party, const string& msg, string& result) {
+  log_debug << "snn public input msg, size: " << msg.size();
 
- private:
-  int _init_aeskeys();
-  void _initialize_mpc_environment();
-};
+  result.clear();
+  vector<int> peers = get_mpc_peers(from_party);
+  if (from_party == partyNum) {
+    //send msg to peers
+    for (size_t i = 0; i < peers.size(); ++i)
+      sendBuf(peers[i], msg.data(), msg.size(), 0);
+  } else {
+    // receive msg
+    result.resize(msg.size());
+    receiveBuf(from_party, (char*)result.data(), msg.size(), 0);
+  }
 
+  log_debug << "snn public input msg ok.";
+  return 0;
+}
+
+} // namespace snn
 } // namespace rosetta

--- a/cc/modules/protocol/mpc/snn/src/impl/division.cpp
+++ b/cc/modules/protocol/mpc/snn/src/impl/division.cpp
@@ -366,44 +366,6 @@ int DivisionV2::funcDivisionMPCV2(
     quotient_vec = curr_q;
     ////funcDotProductMPC(quotient_vec, quotient_sign, shared_quotient_vec, vec_size);
     GetMpcOpInner(DotProduct)->Run(quotient_vec, quotient_sign, shared_quotient_vec, vec_size);
-
-    //////////////// The following is an alternative algorithm for the part II.
-    //		this algorithm is bases on SecureNN whitepaper algorithm 8.
-    // curr_y = denominator_vec;
-    // for(int i  = 1; i < FLOAT_PRECISION_M + 1; ++i) {
-    // 	//value z in whitepaper algorithm 8
-    // 	vector<mpc_t> candidate_x_update = curr_y;
-    // 	vector<mpc_t> candidate_q_update(vec_size, 0);
-    // 	vector<mpc_t> shared_x_monus_z(vec_size, 0);
-    // 	vector<mpc_t> shared_beta(vec_size, 0);
-    // 	if (PRIMARY){
-    // 		// z = y/(z^i)
-    // 		funcTruncate2PC(candidate_x_update, i, vec_size, PARTY_A, PARTY_B);
-    // 		subtractVectors(curr_x, candidate_x_update, shared_x_monus_z, vec_size);
-    // 	}
-    // 	funcRELUPrime3PC(shared_x_monus_z, shared_beta, vec_size);
-    // 	// selection base on beta
-
-    // 	if (PRIMARY) {
-    // 		for(auto j = 0; j < vec_size; ++j) {
-    // 			// share of 2^(f-i)
-    // 			if(partyNum == PARTY_A) {
-    // 				candidate_q_update[j] = 1 << (FLOAT_PRECISION_M - i);
-    // 			} else if(partyNum == PARTY_B) {
-    // 				candidate_q_update[j] = 0;
-    // 			}
-    // 		}
-    // 		if(PRIMARY)
-    // 			funcReconstruct2PC(shared_beta, vec_size, "curr_beta");
-    // 	}
-
-    // 	funcSelectShares3PC(candidate_x_update, shared_beta, candidate_x_update, vec_size);
-    // 	funcSelectShares3PC(candidate_q_update, shared_beta, candidate_q_update, vec_size);
-    // 	addVectors<mpc_t>(curr_q, candidate_q_update, curr_q, vec_size);
-    // 	subtractVectors<mpc_t>(curr_x, candidate_x_update, curr_x, vec_size);
-    // }
-    // quotient_vec = curr_q;
-    // funcDotProductMPC(quotient_vec, quotient_sign, shared_quotient_vec,vec_size);
   }
   if (FOUR_PC) {
     // cout << "ERROR! not support yet!" <<endl;
@@ -477,8 +439,7 @@ int FloorDivision::mpc_floor_division(
     auto curr_x = shared_numerator_vec;
     auto curr_y = shared_denominator_vec;
     // this is just like the original algorithm 8 in PET's paper.
-    // TODO: LEN - 1 - FLOAT_PRECISION_M
-    for (int i = LEN - 1; i >= 0; --i) {
+    for (int i = LEN - 1 - FLOAT_PRECISION_M; i >= 0; --i) {
       auto shared_z = curr_x;
       vector<mpc_t> shared_beta(common_vec_size, 0);
       if (PRIMARY) {
@@ -529,7 +490,7 @@ int FracDivision::mpc_frac_division(
     vector<mpc_t>& shared_quotient_vec = ori_quotient_vec;
     vector<mpc_t> quotient_sign(common_vec_size, 0);
     if (!all_positive) {
-      /// PART 0: determine whether the velues are positive or negative.
+      /// PART 0: determine whether the values are positive or negative.
       vector<mpc_t> shared_numer_sign(common_vec_size, 0);
       GetMpcOpInner(ComputeMSB)->Run3PC(shared_numerator_vec, shared_numer_sign, common_vec_size);
       

--- a/cc/modules/protocol/mpc/snn/src/impl/local.cpp
+++ b/cc/modules/protocol/mpc/snn/src/impl/local.cpp
@@ -41,6 +41,22 @@ void funcTruncate2PC(vector<mpc_t>& a, size_t power, size_t size, size_t party_1
   }
 }
 
+void funcTruncate2PC_many(vector<mpc_t>& a, vector<size_t> power, size_t size, size_t party_1, size_t party_2) {
+  if (!PRIMARY)
+    return;
+  assert((partyNum == party_1 || partyNum == party_2) && "Truncate called by spurious parties");
+
+  if (partyNum == party_1) {
+    for (size_t i = 0; i < size; ++i)
+      a[i] = static_cast<mpc_t>(static_cast<signed_mpc_t>(a[i]) >> power[i]);
+  }
+
+  if (partyNum == party_2) {
+    for (size_t i = 0; i < size; ++i)
+      a[i] = -static_cast<mpc_t>(static_cast<signed_mpc_t>(-a[i]) >> power[i]);
+  }
+}
+
 void funcTruncateElem2PC(mpc_t& a, size_t power, size_t party_1, size_t party_2) {
   assert((partyNum == party_1 || partyNum == party_2) && "Truncate called by spurious parties");
 

--- a/cc/modules/protocol/mpc/snn/src/impl/log.cpp
+++ b/cc/modules/protocol/mpc/snn/src/impl/log.cpp
@@ -177,10 +177,10 @@ void Log::mpc_log_v2(const vector<mpc_t>& shared_X,
 		return;
    	}
 	
-   	// actually we will use the [start, end)-style for each segement!
+   	// actually we will use the [start, end)-style for each segment!
    	vector<mpc_t> curr_power_list;
    	vector<mpc_t> curr_coff_list;
-   	// some temprorary variables
+   	// some temporary variables
 	vector<mpc_t> shared_cmp_init(vec_size, 0);
 	vector<mpc_t> shared_cmp_end(vec_size, 0);
    	vector<mpc_t> shared_init(vec_size, 0);
@@ -198,7 +198,7 @@ void Log::mpc_log_v2(const vector<mpc_t>& shared_X,
 		//     cout << MpcTypeToFloat(curr_coff_list[i]) << "*X^" << 
 		//  			to_readable_hex(curr_power_list[i]) << " + ";
 		// }
-		// S1: use ReLUPrime to get whether to use this segemnt[ multiplier is 0 or 1]
+		// S1: use ReLUPrime to get whether to use this segment[ multiplier is 0 or 1]
 		/// 1.1 check start point
 		// x >= start && (1 - (x >= end))
 		shared_cmp_init = shared_X;
@@ -256,11 +256,11 @@ void Log::mpc_log_v2(const mpc_t& shared_X,
 		cout << "ERROR! empty polynomials in log_v2." << endl; 
 		return;
    	}
-   	// actually we will use the [start, end)-style for each segement!
+   	// actually we will use the [start, end)-style for each segment!
    	vector<mpc_t> curr_power_list;
    	vector<mpc_t> curr_coff_list;
    	mpc_t shared_seg_multiplier = 1;
-   	// some temprorary variables
+   	// some temporary variables
    	vector<mpc_t> shared_cmp(2, 0);
    	vector<mpc_t> shared_init(1, 0);
    	vector<mpc_t> shared_end(1, 0);

--- a/cc/modules/protocol/mpc/snn/src/impl/logical.cpp
+++ b/cc/modules/protocol/mpc/snn/src/impl/logical.cpp
@@ -1,0 +1,223 @@
+// ==============================================================================
+// Copyright 2020 The LatticeX Foundation
+// This file is part of the Rosetta library.
+//
+// The Rosetta library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Rosetta library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Rosetta library. If not, see <http://www.gnu.org/licenses/>.
+// ==============================================================================
+#include "cc/modules/protocol/mpc/snn/src/impl/op_impl.h"
+
+namespace rosetta {
+namespace snn {
+
+int LogicalAND::funcLogicalOp(
+  const vector<mpc_t> X,
+  const vector<mpc_t> Y,
+  vector<mpc_t>& Z,
+  size_t size) {
+  Z.resize(size);
+  GetMpcOpInner(DotProduct)->Run(X, Y, Z, size);
+  return 0;
+}
+int LogicalAND::funcLogicalOp(
+  const vector<mpc_t> X,
+  const vector<string> sY,
+  vector<mpc_t>& Z,
+  size_t size) {
+  Z.resize(size);
+  vector<double> dY(size, 0);
+  vector<mpc_t> Y(size, 0);
+  rosetta::convert::from_double_str(sY, dY);
+  convert_double_to_mpctype(dY, Y);
+
+  ///////////////////////////////////
+  for (size_t i = 0; i < size; i++) {
+    Z[i] = X[i] * Y[i];
+  }
+  if (PRIMARY)
+    funcTruncate2PC(Z, FLOAT_PRECISION_M, size, PARTY_A, PARTY_B);
+  ///////////////////////////////////
+  return 0;
+}
+
+int LogicalOR::funcLogicalOp(
+  const vector<mpc_t> X,
+  const vector<mpc_t> Y,
+  vector<mpc_t>& Z,
+  size_t size) {
+  vector<mpc_t> sum(size, 0);
+  addVectors<mpc_t>(X, Y, sum, size);
+  vector<mpc_t> prod(size, 0);
+  GetMpcOpInner(DotProduct)->Run(X, Y, prod, size);
+  subtractVectors(sum, prod, Z, size);
+
+#if 0 // internal test [yl]
+  {
+    vector<vector<mpc_t>> XX;
+    vector<mpc_t> ZZ, RR;
+    XX.push_back(X);
+    XX.push_back(Y);
+    XX.push_back(Z);
+    XX.push_back(Y);
+    XX.push_back(Z);
+    ZZ = Z;
+    GetMpcOpInner(LogicalXOR)->Run(XX, ZZ);
+    RR.resize(ZZ.size());
+    GetMpcOpInner(Reconstruct2PC)->Run(ZZ, RR);
+    cout << "RR[0]:" << RR[0] << endl;
+  }
+#endif
+
+  return 0;
+}
+int LogicalOR::funcLogicalOp(
+  const vector<mpc_t> X,
+  const vector<string> sY,
+  vector<mpc_t>& Z,
+  size_t size) {
+  Z.resize(size);
+  vector<double> dY(size, 0);
+  vector<mpc_t> Y(size, 0);
+  rosetta::convert::from_double_str(sY, dY);
+  convert_double_to_mpctype(dY, Y);
+
+  ///////////////////////////////////
+  vector<mpc_t> sum = X;
+  if (partyNum == PARTY_A) {
+    // X add Y in P0, X add 0 in P1/P2
+    addVectors<mpc_t>(X, Y, sum, size);
+  }
+
+  vector<mpc_t> prod(size, 0);
+  for (size_t i = 0; i < size; i++) {
+    prod[i] = X[i] * Y[i];
+  }
+  if (PRIMARY)
+    funcTruncate2PC(prod, FLOAT_PRECISION_M, size, PARTY_A, PARTY_B);
+
+  subtractVectors(sum, prod, Z, size);
+  ///////////////////////////////////
+  return 0;
+}
+
+int LogicalXOR::funcLogicalOp(
+  const vector<mpc_t> X,
+  const vector<mpc_t> Y,
+  vector<mpc_t>& Z,
+  size_t size) {
+  Z.resize(size);
+
+  vector<mpc_t> sum(size, 0);
+  addVectors<mpc_t>(X, Y, sum, size);
+  vector<mpc_t> prod(size, 0);
+  GetMpcOpInner(DotProduct)->Run(X, Y, prod, size);
+  if (PRIMARY) {
+    for (int i = 0; i < size; ++i) {
+      prod[i] = prod[i] << 1;
+    }
+  }
+  subtractVectors(sum, prod, Z, size);
+
+  return 0;
+}
+
+int LogicalXOR::funcLogicalOp(
+  const vector<mpc_t> X,
+  const vector<string> sY,
+  vector<mpc_t>& Z,
+  size_t size) {
+  Z.resize(size);
+  vector<double> dY(size, 0);
+  vector<mpc_t> Y(size, 0);
+  rosetta::convert::from_double_str(sY, dY);
+  convert_double_to_mpctype(dY, Y);
+
+  ///////////////////////////////////
+  vector<mpc_t> sum = X;
+  if (partyNum == PARTY_A) {
+    // X add Y in P0, X add 0 in P1/P2
+    addVectors<mpc_t>(X, Y, sum, size);
+  }
+
+  vector<mpc_t> prod(size, 0);
+  for (size_t i = 0; i < size; i++) {
+    prod[i] = X[i] * Y[i];
+  }
+  if (PRIMARY)
+    funcTruncate2PC(prod, FLOAT_PRECISION_M, size, PARTY_A, PARTY_B);
+  if (PRIMARY) {
+    for (int i = 0; i < size; ++i) {
+      prod[i] = prod[i] << 1;
+    }
+  }
+  subtractVectors(sum, prod, Z, size);
+  ///////////////////////////////////
+  return 0;
+}
+
+int LogicalNOT::funcLogicalOp(const vector<mpc_t> X, vector<mpc_t>& Z, size_t size) {
+  Z.resize(size);
+  vector<mpc_t> one(size, 1 << (FLOAT_PRECISION_M - 1));
+  GetMpcOpInner(Sub)->Run(one, X, Z, size);
+  return 0;
+}
+
+//////////
+int LogicalOp::funcLogicalOp_(const vector<vector<mpc_t>> XX, vector<mpc_t>& Z) {
+  Z.clear();
+  int k = XX.size();
+  int d = log2ceil(k);
+  if (k == 0) {
+    Z.resize(0);
+    return 0;
+  }
+  if (k == 1) {
+    Z = XX[0];
+    return 0;
+  }
+  //cout << "k:" << k << endl;
+
+  int size = XX[0].size();
+  vector<mpc_t> hX, hY, hZ; // verctorization
+  if (k & 1 == 1) { // odd
+    for (int i = 0; i < (k - 1) / 2; i++) {
+      hX.insert(hX.end(), XX[i * 2].begin(), XX[i * 2].end());
+      hY.insert(hY.end(), XX[i * 2 + 1].begin(), XX[i * 2 + 1].end());
+    }
+    funcLogicalOp(hX, hY, hZ, hX.size());
+    vector<vector<mpc_t>> hXX;
+    for (int i = 0; i < k / 2; i++) {
+      vector<mpc_t> X(hZ.begin() + size * i, hZ.begin() + size * (i + 1));
+      hXX.push_back(X);
+    }
+    hXX.push_back(XX[k - 1]);
+    funcLogicalOp_(hXX, Z);
+  } else {
+    for (int i = 0; i < k / 2; i++) {
+      hX.insert(hX.end(), XX[i * 2].begin(), XX[i * 2].end());
+      hY.insert(hY.end(), XX[i * 2 + 1].begin(), XX[i * 2 + 1].end());
+    }
+    funcLogicalOp(hX, hY, hZ, hX.size());
+    vector<vector<mpc_t>> hXX;
+    for (int i = 0; i < k / 2; i++) {
+      vector<mpc_t> X(hZ.begin() + size * i, hZ.begin() + size * (i + 1));
+      hXX.push_back(X);
+    }
+    funcLogicalOp_(hXX, Z);
+  }
+
+  return 0;
+}
+
+} // namespace snn
+} // namespace rosetta

--- a/cc/modules/protocol/mpc/snn/src/impl/mpc_basic.cpp
+++ b/cc/modules/protocol/mpc/snn/src/impl/mpc_basic.cpp
@@ -212,7 +212,7 @@ int ComputeMSB::funcComputeMSB3PC(const vector<mpc_t>& a, vector<mpc_t>& b, size
 // a,b,c are shared across PARTY_A, PARTY_B
 int SelectShares::funcSelectShares3PC(
   const vector<mpc_t>& a, const vector<mpc_t>& b, vector<mpc_t>& c, size_t size) {
-  assert(THREE_PC && "funcSelectShares3PC called in non-3PC mdoe");
+  assert(THREE_PC && "funcSelectShares3PC called in non-3PC mode");
 
   //funcDotProductMPC(a, b, c, size);
   GetMpcOpInner(DotProduct)->Run(a, b, c, size);
@@ -222,7 +222,7 @@ int SelectShares::funcSelectShares3PC(
 
 int Square::funcSquareMPC(const vector<mpc_t>& a, vector<mpc_t>& b, size_t size)
 {
-  assert(THREE_PC && "funcSelectShares3PC called in non-3PC mdoe");
+  assert(THREE_PC && "funcSelectShares3PC called in non-3PC mode");
 
   //funcDotProductMPC(a, a, c, size);
   GetMpcOpInner(DotProduct)->Run(a, a, b, size);

--- a/cc/modules/protocol/mpc/snn/src/impl/mpc_nn.cpp
+++ b/cc/modules/protocol/mpc/snn/src/impl/mpc_nn.cpp
@@ -29,6 +29,144 @@ using namespace rosetta;
 
 namespace rosetta {
 namespace snn {
+// Specificated version for reducing round complexity
+int SigmoidCrossEntropy::sigmoid_cross_entropy_batch(const vector<mpc_t>& shared_logits,
+                                            const vector<mpc_t>& shared_labels,
+                                            vector<mpc_t>& shared_result,
+                                            size_t vec_size) {
+    // cout << "sigmoid_cross_entropy_batch !" << endl;
+    ///********************1. prepare all data for batch-ReluPrime. 
+    vector<mpc_t> batch_comp_X;
+    batch_comp_X.insert(batch_comp_X.end(), shared_logits.begin(), shared_logits.end());
+    
+    string my_func = "LOG_CE";
+    // we know that this functionality need single segment.
+    vector<mpc_t> power_list;
+	vector<mpc_t> coff_list;
+    vector<ConstPolynomial> * log_ce_p = NULL;
+    if(!PolyConfFactory::get_func_polys(my_func, &log_ce_p)) {
+        // TODO: throw exception
+        cout << "ERROR! can not find polynomials for func " << my_func <<endl;
+        return -1;
+    }
+	auto seg_size = log_ce_p->size();
+   	log_ce_p->at(0).get_power_list(power_list);
+	log_ce_p->at(0).get_coff_list(coff_list);
+    auto end_v = log_ce_p->at(0).get_end();
+    vector<mpc_t> UPPER_V(vec_size, 0);
+    if(partyNum == PARTY_A) {
+        vector<mpc_t> tmp_vec(vec_size, end_v);
+        UPPER_V.swap(tmp_vec);
+    }
+
+    vector<mpc_t> upper_bound_minus_logits(vec_size);
+    vector<mpc_t> logits_plus_upper_bound(vec_size);
+
+    subtractVectors<mpc_t>(UPPER_V, shared_logits, upper_bound_minus_logits, vec_size);
+    addVectors<mpc_t>(shared_logits, UPPER_V, logits_plus_upper_bound, vec_size);
+    
+    batch_comp_X.insert(batch_comp_X.end(),
+                        upper_bound_minus_logits.begin(),
+                        upper_bound_minus_logits.end());
+
+    batch_comp_X.insert(batch_comp_X.end(),
+                        logits_plus_upper_bound.begin(),
+                        logits_plus_upper_bound.end());
+    
+    ///********************2.  call the costly ReluPrime operation in one shot.
+    vector<mpc_t> batch_cmp_res(batch_comp_X.size());
+    GetMpcOpInner(ReluPrime)->Run(batch_comp_X, batch_cmp_res, batch_comp_X.size());
+    batch_comp_X.clear();
+
+    ///********************3.  unpack  results and get related results.
+    vector<mpc_t> max_part_bit;
+    max_part_bit.insert(max_part_bit.end(), batch_cmp_res.begin(), batch_cmp_res.begin() +vec_size);
+    vector<mpc_t> upper_bound_minus_logits_bit;
+    upper_bound_minus_logits_bit.insert(upper_bound_minus_logits_bit.end(), 
+                                      batch_cmp_res.begin() + vec_size,
+                                      batch_cmp_res.begin() + 2* vec_size);
+    vector<mpc_t>  logits_plus_upper_bound_bit;
+    logits_plus_upper_bound_bit.insert(logits_plus_upper_bound_bit.end(),
+                                      batch_cmp_res.begin() + 2* vec_size,
+                                      batch_cmp_res.end());
+    batch_cmp_res.clear();
+    
+    // 3.1 get Logits Sign multiplier.
+    vector<double> SHARED_TWO(vec_size, 2);
+    vector<mpc_t> SHARED_NEG_ONE(vec_size, 0);
+    if (partyNum == PARTY_A) {
+        SHARED_NEG_ONE = vector<mpc_t>(vec_size, FloatToMpcType(-1));
+    }
+    vector<mpc_t> shared_x_multiplier(vec_size, 0);
+    vector<mpc_t> temp_mul_res(vec_size);
+    // this is local
+    GetMpcOpInner(DotProduct)->Run(SHARED_TWO, max_part_bit, temp_mul_res, vec_size);
+    addVectors<mpc_t>(SHARED_NEG_ONE, temp_mul_res, shared_x_multiplier, vec_size);
+    temp_mul_res.clear();
+    SHARED_TWO.clear();
+    SHARED_NEG_ONE.clear();
+
+    ///******************** 4. pack data for batch DotProduct[Mul]
+    vector<mpc_t> batch_mul_op_left;
+    vector<mpc_t> batch_mul_op_right;
+
+    batch_mul_op_left.insert(batch_mul_op_left.end(), max_part_bit.begin(), max_part_bit.end());
+    batch_mul_op_right.insert(batch_mul_op_right.end(), shared_logits.begin(), shared_logits.end());
+
+    batch_mul_op_left.insert(batch_mul_op_left.end(), shared_x_multiplier.begin(), shared_x_multiplier.end());
+    batch_mul_op_right.insert(batch_mul_op_right.end(), shared_logits.begin(), shared_logits.end());
+
+    batch_mul_op_left.insert(batch_mul_op_left.end(), shared_labels.begin(), shared_labels.end());
+    batch_mul_op_right.insert(batch_mul_op_right.end(), shared_logits.begin(), shared_logits.end());
+
+    batch_mul_op_left.insert(batch_mul_op_left.end(), 
+                            upper_bound_minus_logits_bit.begin(), upper_bound_minus_logits_bit.end());
+    batch_mul_op_right.insert(batch_mul_op_right.end(), 
+                            logits_plus_upper_bound_bit.begin(), logits_plus_upper_bound_bit.end());
+    
+    vector<mpc_t>  batch_mul_op_res(batch_mul_op_right.size());
+    GetMpcOpInner(DotProduct)->Run(batch_mul_op_left, 
+                                    batch_mul_op_right,
+                                    batch_mul_op_res, batch_mul_op_left.size());
+    batch_mul_op_left.clear();
+    batch_mul_op_right.clear();
+
+    ///******************** 5.  unpack MUL result.
+    // max(logit, 0)
+    vector<mpc_t> max_part;
+    max_part.insert(max_part.end(), batch_mul_op_res.begin(), batch_mul_op_res.begin() + vec_size);
+    // 5.1 abs(logit)
+    vector<mpc_t> _abs;
+    _abs.insert(_abs.end(), 
+              batch_mul_op_res.begin() + vec_size,
+              batch_mul_op_res.begin() + 2 * vec_size);
+    // logit * label
+    vector<mpc_t> prod_part;
+    prod_part.insert(prod_part.end(), 
+                    batch_mul_op_res.begin() + 2 * vec_size, 
+                    batch_mul_op_res.begin() + 3 * vec_size);
+    // clipped_sign
+    vector<mpc_t> no_need_clip_bit;
+    no_need_clip_bit.insert(no_need_clip_bit.end(), 
+                    batch_mul_op_res.begin() + 3 * vec_size, 
+                    batch_mul_op_res.end());
+    batch_mul_op_res.clear();
+    
+    ///******************** 6. get log(1 + exp(-X) part with polynomial.
+    vector<mpc_t> log_part(vec_size);
+    vector<mpc_t> LOWER_CLIP_CONST(vec_size);
+    if (partyNum == PARTY_A) {
+        LOWER_CLIP_CONST = vector<mpc_t>(vec_size, FloatToMpcType(0.0003));
+    }
+    GetMpcOpInner(Polynomial)->mpc_uni_polynomial(_abs, power_list, coff_list, log_part);
+    GetMpcOpInner(Select1Of2)->Run(log_part, LOWER_CLIP_CONST, no_need_clip_bit, log_part, vec_size);   
+    // 7. collect all parts
+    // max(logit, 0) - logit * label
+    subtractVectors<mpc_t>(max_part, prod_part, shared_result, vec_size);
+    addVectors<mpc_t>(shared_result, log_part, shared_result, vec_size);
+    return 0;
+}
+
 /*
     max(logit, 0) - logit * label + log(1 + exp(-abs(x)))
 */
@@ -151,7 +289,7 @@ void SigmoidCrossEntropy::CELog(const vector<mpc_t>& shared_X,
         vector<mpc_t> LOWER_BOUND(vec_size, FloatToMpcType(0.00015));
         vector<mpc_t> curr_res(vec_size, 0);
         vector<mpc_t> tmp_v(vec_size);
-        log_debug << "DEBUG CELOG, calling vectorization mpc_uni_polynomial" << endl;
+        log_debug << "DEBUG CE LOG, calling vectorization mpc_uni_polynomial" << endl;
         GetMpcOpInner(Polynomial)->mpc_uni_polynomial(curr_X, power_list, coff_list, tmp_v);
         for (int i = 0; i < vec_size; ++i) {
             curr_res[i] = CoffDown(tmp_v[i]);

--- a/cc/modules/protocol/mpc/snn/src/impl/reconstruct.cpp
+++ b/cc/modules/protocol/mpc/snn/src/impl/reconstruct.cpp
@@ -55,7 +55,7 @@ int Reconstruct2PC::funcReconstruct2PC(
   if (a.size() < size)
     size = a.size();
 
-  cout << "----  recons 2222" << endl;
+  //cout << "----  recons 2222" << endl;
   out.resize(size, 0);
   int tempPartyA = (recv_party == PARTY_A) ? PARTY_A : PARTY_B;
   int tempPartyB = (recv_party == PARTY_A) ? PARTY_B : PARTY_A;

--- a/cc/modules/protocol/mpc/snn/src/impl/reduce.cpp
+++ b/cc/modules/protocol/mpc/snn/src/impl/reduce.cpp
@@ -16,60 +16,118 @@
 // along with the Rosetta library. If not, see <http://www.gnu.org/licenses/>.
 // ==============================================================================
 #include "cc/modules/protocol/mpc/snn/src/impl/op_impl.h"
-
+#include <cmath>
 namespace rosetta {
 namespace snn {
 
-// Chunk wise maximum of a vector of size rows*columns and maximum is caclulated of every
-// column number of elements. max is a vector of size rows. maxIndex contains the index of
-// the maximum value.
-// PARTY_A, PARTY_B start with the shares in a and {A,B} and {C,D} have the results in
-// max and maxIndex.
+// Chunk wise maximum of a vector of size rows*columns and maximum is calculated of every
+// column number of elements. max is a vector of size rows.
+// PARTY_A, PARTY_B start with the shares in a and {A,B} and {C,D} have the results in `max`.
+// ToDo(GeorgeShi): If need_index is set to true, maxIndex contains the index of the maximum value.
 int Max::funcMaxMPC(
   const vector<mpc_t>& a,
   vector<mpc_t>& max,
   vector<mpc_t>& maxIndex,
   size_t rows,
-  size_t columns) {
+  size_t columns,
+  bool need_index) {
   if (THREE_PC) {
-    vector<mpc_t> diff(rows), diffIndex(rows), rp(rows), indexShares(rows * columns, 0);
+    // vector<mpc_t> diffIndex, indexShares;
+    // if (need_index) {
+    //   diffIndex.resize(rows);
+    //   indexShares.resize(rows * columns);
+      
+    //   for (size_t i = 0; i < rows; ++i) {
+    //     maxIndex[i] = 0;
+    //     for (size_t j = 0; j < columns; ++j)
+    //       indexShares[i * columns + j] = j;
+    //   }
+    // }
+    // if(PRIMARY) {
+    //   GetMpcOpInner(Reconstruct2PC)->Run(a, a.size(), "input value");
+    // }
+    // tree-structure to reduce iteration to call inner OPs.
+    int depth = ceil(log2(columns));
+    // cout << "debug: depth " << depth << endl;
+    int curr_L = columns;
+    vector<mpc_t> level_data = a;
+    vector<mpc_t> first_v;
+    vector<mpc_t> second_v;
+    vector<mpc_t> diff_v;
+    vector<mpc_t> comp_res;
+    bool need_pad = false;
+    for (size_t i = 0; i < depth; ++i) {
+      // cout << "depth " << i << endl;
+      // cout << "curr L:" << curr_L << endl;
 
-    for (size_t i = 0; i < rows; ++i) {
-      max[i] = a[i * columns];
-      maxIndex[i] = 0;
+      int next_L = ceil( curr_L / 2.0);
+      vector<mpc_t> new_data;
+      first_v.clear();
+      second_v.clear();
+      diff_v.clear();
+      comp_res.clear();
+      // If the numbers in a row is odd, there is no need to comapre the last element. 
+      if (curr_L % 2 == 1) {
+        need_pad = true;
+      }
+      // if(PRIMARY) {
+      //     	GetMpcOpInner(Reconstruct2PC)->Run(level_data, level_data.size(), "curr level input value");
+    	// }
+      // pack for batch Relu.
+      for (int j = 0; j < rows; ++j) {
+        for (int k = 0; k < curr_L - 1; k = k + 2) {
+          first_v.push_back(level_data[j*curr_L + k]);
+          second_v.push_back(level_data[j*curr_L + k + 1]);
+          diff_v.push_back(first_v.back() - second_v.back());
+        }
+      }
+
+      int comp_size = diff_v.size();
+      comp_res.resize(comp_size);
+      new_data.resize(comp_size);
+      GetMpcOpInner(ReluPrime)->Run3PC(diff_v, comp_res, comp_size);
+			GetMpcOpInner(Select1Of2)->Run(first_v, second_v, comp_res, new_data, comp_size);
+      // if(PRIMARY) {
+      //     	GetMpcOpInner(Reconstruct2PC)->Run(first_v, first_v.size(), "first_v");
+    	// }
+      // if(PRIMARY) {
+      //     	GetMpcOpInner(Reconstruct2PC)->Run(second_v, second_v.size(), "second_v");
+    	// }
+      // if(PRIMARY) {
+      //     	GetMpcOpInner(Reconstruct2PC)->Run(new_data, new_data.size(), "COMP result");
+    	// }
+      int comp_res_col = comp_size / rows;
+      // unpack for next layer.
+      vector<mpc_t> next_level_data;
+      for ( int j = 0; j < rows; ++j) {
+        for (int k = 0; k <= next_L - 1; ++k) {
+          if (k == next_L - 1) {
+            // reserve the last element if needed.
+            if(need_pad && (next_L != 1)) {
+              next_level_data.push_back(level_data[j * curr_L + curr_L - 1]);
+            } else {
+              next_level_data.push_back(new_data[j * comp_res_col + k]);
+            }
+          } else {
+            next_level_data.push_back(new_data[j * comp_res_col + k]);
+          }
+        }
+      }
+      level_data = next_level_data;
+      curr_L = next_L;
+      // debug 
+		  // if(PRIMARY) {
+      //     	GetMpcOpInner(Reconstruct2PC)->Run(level_data, level_data.size(), "curr level value");
+    	// }
     }
-
-    if (partyNum == PARTY_A) {
-      for (size_t i = 0; i < rows; ++i)
-        for (size_t j = 0; j < columns; ++j)
-          indexShares[i * columns + j] = j;
-    }
-
-    for (size_t i = 1; i < columns; ++i) {
-      for (size_t j = 0; j < rows; ++j)
-        diff[j] = max[j] - a[j * columns + i];
-
-      for (size_t j = 0; j < rows; ++j)
-        diffIndex[j] = maxIndex[j] - indexShares[j * columns + i];
-
-      ////funcRELUPrime3PC(diff, rp, rows);
-      GetMpcOpInner(ReluPrime)->Run3PC(diff, rp, rows);
-
-      ////funcSelectShares3PC(diff, rp, max, rows);
-      GetMpcOpInner(SelectShares)->Run3PC(diff, rp, max, rows);
-      ////funcSelectShares3PC(diffIndex, rp, maxIndex, rows);
-      GetMpcOpInner(SelectShares)->Run3PC(diffIndex, rp, maxIndex, rows);
-
-      for (size_t j = 0; j < rows; ++j)
-        max[j] = max[j] + a[j * columns + i];
-
-      for (size_t j = 0; j < rows; ++j)
-        maxIndex[j] = maxIndex[j] + indexShares[j * columns + i];
+    max = level_data;
+      if (need_index) {
+        log_error << "NOT supported yet!" << endl;
     }
   }
 
   if (FOUR_PC) {
-    // I have removed 4PC, by yyl, 202.03.12
+    // I have removed 4PC, by yyl, 2020.03.12
   }
   return 0;
 }
@@ -130,63 +188,86 @@ int MaxIndex::funcMaxIndexMPC(
   return 0;
 }
 
-// Chunk wise minimum of a vector of size rows*columns and minimum is caclulated of every
-// column number of elements. min is a vector of size rows. minIndex contains the index of
-// the minimum value.
-// PARTY_A, PARTY_B start with the shares in a and {A,B} and {C,D} have the results in
-// min and minIndex.
+// Chunk wise minimum of a vector of size rows*columns and minimum is calculated of every
+// column number of elements. max is a vector of size rows.
+// PARTY_A, PARTY_B start with the shares in a and {A,B} and {C,D} have the results in `min`.
+// ToDo(GeorgeShi): If need_index is set to true, minIndex contains the index of the minimum value.
 int Min::funcMinMPC(
   const vector<mpc_t>& a,
   vector<mpc_t>& min,
   vector<mpc_t>& minIndex,
   size_t rows,
-  size_t columns) {
+  size_t columns,
+  bool need_index) {
   if (THREE_PC) {
-    vector<mpc_t> diff(rows), diffIndex(rows), rp(rows), indexShares(rows * columns, 0);
+    // if(PRIMARY) {
+    //   GetMpcOpInner(Reconstruct2PC)->Run(a, a.size(), "input value");
+    // }
+    // tree-structure to reduce iteration to call inner OPs.
+    int depth = ceil(log2(columns));
+    int curr_L = columns;
+    vector<mpc_t> level_data = a;
+    vector<mpc_t> first_v;
+    vector<mpc_t> second_v;
+    vector<mpc_t> diff_v;
+    vector<mpc_t> comp_res;
+    bool need_pad = false;
+    for (size_t i = 0; i < depth; ++i) {
+      int next_L = ceil(curr_L / 2.0);
+      vector<mpc_t> new_data;
+      first_v.clear();
+      second_v.clear();
+      diff_v.clear();
+      comp_res.clear();
+      // If the numbers in a row is odd, there is no need to comapre the last element. 
+      if (curr_L % 2 == 1) {
+        need_pad = true;
+      }
 
-    for (size_t i = 0; i < rows; ++i) {
-      min[i] = a[i * columns];
-      minIndex[i] = 0;
+      // pack for batch Relu.
+      for (int j = 0; j < rows; ++j) {
+        for (int k = 0; k < curr_L - 1; k = k + 2) {
+          first_v.push_back(level_data[j*curr_L + k]);
+          second_v.push_back(level_data[j*curr_L + k + 1]);
+          diff_v.push_back(first_v.back() - second_v.back());
+        }
+      }
+
+      int comp_size = diff_v.size();
+      comp_res.resize(comp_size);
+      new_data.resize(comp_size);
+      GetMpcOpInner(ReluPrime)->Run3PC(diff_v, comp_res, comp_size);
+      // this is the ONLY difference with Max::funcMaxMPC, so we may clean the code in future.
+			GetMpcOpInner(Select1Of2)->Run(second_v, first_v, comp_res, new_data, comp_size);
+      
+      // unpack for next layer.
+      int comp_res_col = comp_size / rows;
+      vector<mpc_t> next_level_data;
+      for ( int j = 0; j < rows; ++j) {
+        for (int k = 0; k <= next_L - 1; ++k) {
+          if (k == next_L - 1) {
+            // reserve the last element if needed.
+            if(need_pad && (next_L != 1)) {
+              next_level_data.push_back(level_data[j * curr_L + curr_L - 1]);
+            } else {
+              next_level_data.push_back(new_data[j * comp_res_col + k]);
+            }
+          } else {
+            next_level_data.push_back(new_data[j * comp_res_col + k]);
+          }
+        }
+      }
+      level_data = next_level_data;
+      curr_L = next_L;
     }
-
-    if (partyNum == PARTY_A) {
-      for (size_t i = 0; i < rows; ++i)
-        for (size_t j = 0; j < columns; ++j)
-          indexShares[i * columns + j] = j;
+    min = level_data;
+      if (need_index) {
+        log_error << "NOT supported yet!" << endl;
     }
-
-    for (size_t i = 1; i < columns; ++i) {
-      for (size_t j = 0; j < rows; ++j)
-        diff[j] = a[j * columns + i] - min[j];
-
-      for (size_t j = 0; j < rows; ++j)
-        diffIndex[j] = indexShares[j * columns + i] - minIndex[j];
-
-      ////funcRELUPrime3PC(diff, rp, rows);
-      GetMpcOpInner(ReluPrime)->Run3PC(diff, rp, rows);
-
-      // // just local multiply minus one
-      // for (size_t idx = 0; idx < rp.size(); ++idx) {
-      //   rp[idx] = rp[idx] * FloatToMpcType(-1);
-      // }
-      // funcTruncate2PC(rp, FLOAT_PRECISION_M, rp.size(), PARTY_A, PARTY_B);
-
-      ////funcSelectShares3PC(diff, rp, min, rows);
-      GetMpcOpInner(SelectShares)->Run3PC(diff, rp, min, rows);
-      ////funcSelectShares3PC(diffIndex, rp, minIndex, rows);
-      GetMpcOpInner(SelectShares)->Run3PC(diffIndex, rp, minIndex, rows);
-
-      for (size_t j = 0; j < rows; ++j)
-        min[j] = a[j * columns + i] - min[j];
-
-      for (size_t j = 0; j < rows; ++j)
-        minIndex[j] = indexShares[j * columns + i] - minIndex[j];
-    }
-  } //THREE_PC
+  }
 
   if (FOUR_PC) {
-    // I have removed 4PC, by yyl, 202.03.12
-    //throw;
+    // I have removed 4PC, by yyl, 2020.03.12
   }
   return 0;
 }
@@ -200,51 +281,6 @@ int MinIndex::funcMinIndexMPC(
   size_t columns) {
   LOGI("funcMinIndexMPC not implements, [WARNING] !!!!!\n");
 
-  //   assert(((columns & (columns - 1)) == 0) && "funcMinIndexMPC works only for power of 2 columns");
-  //   assert((columns < 257) && "This implementation does not support larger than 257 columns");
-
-  //   vector<small_mpc_t> random(rows);
-
-  //   if (PRIMARY) {
-  //     vector<small_mpc_t> toSend(rows);
-  //     for (size_t i = 0; i < rows; ++i)
-  //       toSend[i] = (small_mpc_t)minIndex[i] % columns;
-
-  //     populateRandomVector<small_mpc_t>(random, rows, "COMMON", "POSITIVE");
-  //     if (partyNum == PARTY_A)
-  //       addVectors<small_mpc_t>(toSend, random, toSend, rows);
-
-  //     sendVector<small_mpc_t>(toSend, PARTY_C, rows);
-  //   }
-
-  //   if (partyNum == PARTY_C) {
-  //     vector<small_mpc_t> index(rows), temp(rows);
-  //     vector<mpc_t> vec(rows * columns, 0), share_1(rows * columns), share_2(rows * columns);
-  //     receiveVector<small_mpc_t>(index, PARTY_A, rows);
-  //     receiveVector<small_mpc_t>(temp, PARTY_B, rows);
-  //     addVectors<small_mpc_t>(index, temp, index, rows);
-
-  //     for (size_t i = 0; i < rows; ++i)
-  //       index[i] = index[i] % columns;
-
-  //     for (size_t i = 0; i < rows; ++i)
-  //       vec[i * columns + index[i]] = 1;
-
-  //     splitIntoShares(vec, share_1, share_2, rows * columns);
-  //     sendVector<mpc_t>(share_1, PARTY_A, rows * columns);
-  //     sendVector<mpc_t>(share_2, PARTY_B, rows * columns);
-  //   }
-
-  //   if (PRIMARY) {
-  //     receiveVector<mpc_t>(a, PARTY_C, rows * columns);
-  //     size_t offset = 0;
-  //     for (size_t i = 0; i < rows; ++i) {
-  //       rotate(
-  //         a.begin() + offset, a.begin() + offset + (random[i] % columns),
-  //         a.begin() + offset + columns);
-  //       offset += columns;
-  //     }
-  //   }
   return 0;
 }
 

--- a/cc/modules/protocol/mpc/snn/src/impl/sigmoid.cpp
+++ b/cc/modules/protocol/mpc/snn/src/impl/sigmoid.cpp
@@ -47,8 +47,8 @@ int Sigmoid::funcPrivateCompareMPCEx(
   return 0;
 }
 
-//compare two a commond value r with secret-sharing value a,
-//it functions the same as operaotr>=() ">=", if r >= a, returns 8192 (mean "1"), otherwise returns 0
+//compare two a common value r with secret-sharing value a,
+//it functions the same as operator>=() ">=", if r >= a, returns 8192 (mean "1"), otherwise returns 0
 int Sigmoid::funcPrivateCompareMPCEx2(
   const vector<mpc_t>& r, const vector<mpc_t>& a, vector<mpc_t>& b, size_t size) {
   // LOGI("funcDotProductMPC start");
@@ -86,11 +86,9 @@ int Sigmoid::funcCubeMPC(const vector<mpc_t>& a, vector<mpc_t>& cube, size_t siz
   LOGI("funcCubeMPC run");
   // x * x
   vector<mpc_t> square(size, 0);
-  //funcDotProductMPC(a, a, square, size);
   GetMpcOpInner(DotProduct)->Run(a, a, square, size);
 
   //(x*x) * x
-  //funcDotProductMPC(square, a, cube, size);
   GetMpcOpInner(DotProduct)->Run(square, a, cube, size);
 
   LOGI("funcSquareMPC OK");
@@ -392,9 +390,8 @@ int Sigmoid::funcSigmoidPieceWiseMPC(const vector<mpc_t>& a, vector<mpc_t>& b, s
     LOGW("4PC is not support !");
     return 1;
   } else if (THREE_PC) {
+    int SEG = 5;
     // vector<mpc_t> y = a;
-    vector<mpc_t> y = a;
-
     //params(a,b): (0.0484792, 0.1998976),  (0.1928931, 0.4761351), (0.1928931, 0.5238649),  
     //(0.0484792,0.8001024)
     mpc_t a1 = FloatToMpcType(0.0484792);
@@ -406,61 +403,68 @@ int Sigmoid::funcSigmoidPieceWiseMPC(const vector<mpc_t>& a, vector<mpc_t>& b, s
     mpc_t a4 = FloatToMpcType(0.0484792);
     mpc_t b4 = FloatToMpcType(0.8001024) / 2;
 
+    // vectorization-style to call the costly funcPrivateCompareMPCEx2(ReluPrime) only once.
     //[-4,4]: -4, -2, 0, 2, 4
-    mpc_t y1 = FloatToMpcType(-4);
-    mpc_t y2 = FloatToMpcType(-2);
-    mpc_t y3 = FloatToMpcType(0);
-    mpc_t y4 = FloatToMpcType(2);
-    mpc_t y5 = FloatToMpcType(4);
-    vector<mpc_t> y1_cmp(size, y1);
-    vector<mpc_t> y2_cmp(size, y2);
-    vector<mpc_t> y3_cmp(size, y3);
-    vector<mpc_t> y4_cmp(size, y4);
-    vector<mpc_t> y5_cmp(size, y5);
-    funcPrivateCompareMPCEx2(y1_cmp, y, y1_cmp, size);
-    funcPrivateCompareMPCEx2(y2_cmp, y, y2_cmp, size);
-    funcPrivateCompareMPCEx2(y3_cmp, y, y3_cmp, size);
-    funcPrivateCompareMPCEx2(y4_cmp, y, y4_cmp, size);
-    funcPrivateCompareMPCEx2(y5_cmp, y, y5_cmp, size);
+    vector<mpc_t> batch_cmp_C;
+    batch_cmp_C.insert(batch_cmp_C.end(), size, FloatToMpcType(-4));
+    batch_cmp_C.insert(batch_cmp_C.end(), size, FloatToMpcType(-2));
+    batch_cmp_C.insert(batch_cmp_C.end(), size, FloatToMpcType(0));
+    batch_cmp_C.insert(batch_cmp_C.end(), size, FloatToMpcType(2));
+    batch_cmp_C.insert(batch_cmp_C.end(), size, FloatToMpcType(4));
+    
+    const vector<mpc_t>& X = a;
+    vector<mpc_t> batch_cmp_X;
+    batch_cmp_X.insert(batch_cmp_X.end(), X.begin(), X.end());
+    batch_cmp_X.insert(batch_cmp_X.end(), X.begin(), X.end());
+    batch_cmp_X.insert(batch_cmp_X.end(), X.begin(), X.end());
+    batch_cmp_X.insert(batch_cmp_X.end(), X.begin(), X.end());
+    batch_cmp_X.insert(batch_cmp_X.end(), X.begin(), X.end());
+
+    vector<mpc_t> batch_cmp_res(batch_cmp_X.size());
+    funcPrivateCompareMPCEx2(batch_cmp_C, batch_cmp_X, batch_cmp_res, batch_cmp_X.size());
+    batch_cmp_X.clear();
+    batch_cmp_C.clear();
+
     mpc_t lastOne = FloatToMpcType(1) / 2; // add last 1
 
+    // vectorization for calling communication-costly DotProduct only once 
+    vector<mpc_t> batch_dot_product;
     vector<mpc_t> linear_temp(size);
-    vector<mpc_t> mul_temp(size);
-    vector<mpc_t> out(size, 0);
 
     if (PRIMARY)
-      funcLinearMPC(y, 0 - a1, 0 - b1, linear_temp, size);
-    ////funcDotProductMPC(y1_cmp, linear_temp, mul_temp, size);
-    GetMpcOpInner(DotProduct)->Run(y1_cmp, linear_temp, mul_temp, size);
-    addVectors(out, mul_temp, out, size);
+      funcLinearMPC(X, 0 - a1, 0 - b1, linear_temp, size);
+    batch_dot_product.insert(batch_dot_product.end(), linear_temp.begin(), linear_temp.end());
+
 
     if (PRIMARY)
-      funcLinearMPC(y, a1 - a2, b1 - b2, linear_temp, size);
-    ////funcDotProductMPC(y2_cmp, linear_temp, mul_temp, size);
-    GetMpcOpInner(DotProduct)->Run(y2_cmp, linear_temp, mul_temp, size);
-    addVectors(out, mul_temp, out, size);
+      funcLinearMPC(X, a1 - a2, b1 - b2, linear_temp, size);
+    batch_dot_product.insert(batch_dot_product.end(), linear_temp.begin(), linear_temp.end());
 
     if (PRIMARY)
-      funcLinearMPC(y, a2 - a3, b2 - b3, linear_temp, size);
-    ////funcDotProductMPC(y3_cmp, linear_temp, mul_temp, size);
-    GetMpcOpInner(DotProduct)->Run(y3_cmp, linear_temp, mul_temp, size);
-    addVectors(out, mul_temp, out, size);
+      funcLinearMPC(X, a2 - a3, b2 - b3, linear_temp, size);
+    batch_dot_product.insert(batch_dot_product.end(), linear_temp.begin(), linear_temp.end());
 
     if (PRIMARY)
-      funcLinearMPC(y, a3 - a4, b3 - b4, linear_temp, size);
-    ////funcDotProductMPC(y4_cmp, linear_temp, mul_temp, size);
-    GetMpcOpInner(DotProduct)->Run(y4_cmp, linear_temp, mul_temp, size);
-    addVectors(out, mul_temp, out, size);
+      funcLinearMPC(X, a3 - a4, b3 - b4, linear_temp, size);
+    batch_dot_product.insert(batch_dot_product.end(), linear_temp.begin(), linear_temp.end());
 
     if (PRIMARY)
-      funcLinearMPC(y, a4 /*-0*/, b4 - lastOne, linear_temp, size);
-    ////funcDotProductMPC(y5_cmp, linear_temp, mul_temp, size);
-    GetMpcOpInner(DotProduct)->Run(y5_cmp, linear_temp, mul_temp, size);
-    addVectors(out, mul_temp, out, size);
+      funcLinearMPC(X, a4 /*-0*/, b4 - lastOne, linear_temp, size);
+    batch_dot_product.insert(batch_dot_product.end(), linear_temp.begin(), linear_temp.end());
+    
+    vector<mpc_t> batch_dp_res(batch_dot_product.size());
+    GetMpcOpInner(DotProduct)->Run(batch_cmp_res, batch_dot_product, batch_dp_res, batch_cmp_res.size());
+    batch_cmp_res.clear();
+    batch_dot_product.clear();
 
-    for (size_t i = 0; i < size; i++) {
-      b[i] = out[i] + lastOne;
+    // unpack the vectorization result and sum up.
+    vector<mpc_t> out(size, lastOne);
+    for(int i = 0; i < SEG; ++i) {
+      vector<mpc_t> seg_mul_res(batch_dp_res.begin() + i * size, 
+                                batch_dp_res.begin() + (i + 1) * size);
+      addVectors(out, seg_mul_res, out, size);
     }
+    b = out;
   }
 
   string party = "A";
@@ -658,6 +662,12 @@ int Sigmoid::funcSigmoidChebyshevPolyMPC(const vector<mpc_t>& a, vector<mpc_t>& 
     mpc_t a5 = FloatToMpcType(0.0001825597);
     mpc_t a7 = FloatToMpcType(-0.0000018848);
     mpc_t a9 = FloatToMpcType(0.0000000072);
+    // cout << "------ a1,a3,a5,a7,a9: " << endl;
+    // cout << a1 << endl;
+    // cout << a3 << endl;
+    // cout << a5 << endl;
+    // cout << a7 << endl;
+    // cout << a9 << endl;
 
     vector<mpc_t> x2(size), x3(size), x5(size), x7(size), x9(size);
     auto& x1 = a;

--- a/cc/modules/protocol/mpc/snn/src/snn_protocol.cpp
+++ b/cc/modules/protocol/mpc/snn/src/snn_protocol.cpp
@@ -37,7 +37,7 @@ shared_ptr<ProtocolOps> SnnProtocol::GetOps(const string& op_token) {
   return o;
 }
 
-void SnnProtocol::_initialize_mpc_enviroment() {
+void SnnProtocol::_initialize_mpc_environment() {
   partyNum = my_party_id;
   NUM_OF_PARTIES = 3; /// set to 3PC
   initializeMPC();

--- a/cc/modules/protocol/mpc/snn/src/snn_protocol_ops.h
+++ b/cc/modules/protocol/mpc/snn/src/snn_protocol_ops.h
@@ -37,163 +37,194 @@ class SnnProtocolOps : public ProtocolOps {
   //void SetNetIO(RttIO* io);
 
   // template <typename T>
-  int TfToSecure(const vector<string>& in, vector<string>& out, const attr_type* attr_info = nullptr);
+  int TfToSecure(
+    const vector<string>& in,
+    vector<string>& out,
+    const attr_type* attr_info = nullptr);
 
   // decode the string in protocol-specific format to literal number
   // template <typename T>
-  int SecureToTf(const vector<string>& in, vector<string>& out, const attr_type* attr_info = nullptr);
+  int SecureToTf(
+    const vector<string>& in,
+    vector<string>& out,
+    const attr_type* attr_info = nullptr);
 
   int RandSeed(string op_seed, string& out_str);
 
   int PrivateInput(int party_id, const vector<double>& in_vec, vector<string>& out_str_vec);
 
+  int Broadcast(int from_party, const string& msg, string& result);
+
   //////////////////////////////////    math ops   //////////////////////////////////
   int Add(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int Sub(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int Mul(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int Div(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int Truediv(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int Floordiv(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   //// compare ops ////
   int Less(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int LessEqual(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int Equal(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int NotEqual(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int Greater(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int GreaterEqual(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
   //// compare ////
 
   int Pow(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int Matmul(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
-  int Square(
-    const vector<string>& a, vector<string>& output,
-    const attr_type* attr_info = nullptr);
+  int Square(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
 
   int Negative(
-    const vector<string>& a, vector<string>& output,
+    const vector<string>& a,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
-  int Abs(
-    const vector<string>& a, vector<string>& output,
-    const attr_type* attr_info = nullptr);
+  int Abs(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
 
   int AbsPrime(
-    const vector<string>& a, vector<string>& output,
+    const vector<string>& a,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
-  int Log(
-    const vector<string>& a, vector<string>& output,
-        const attr_type* attr_info = nullptr);
+  int Log(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
 
-  int HLog(
-    const vector<string>& a, vector<string>& output,
-    const attr_type* attr_info = nullptr);
-  
-  int Log1p(
-    const vector<string>& a, vector<string>& output,
-    const attr_type* attr_info = nullptr);
+  int HLog(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
 
-  int Max(
-    const vector<string>& a, vector<string>& output,
-    const attr_type* attr_info = nullptr);
+  int Log1p(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
 
-  int Min(
-    const vector<string>& a, vector<string>& output,
-    const attr_type* attr_info = nullptr);
+  int Max(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
 
-  int Mean(
-    const vector<string>& a, vector<string>& output,
-    const attr_type* attr_info = nullptr);
+  int Min(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
 
-  int Sum(
-    const vector<string>& a, vector<string>& output,
-    const attr_type* attr_info = nullptr);
+  int Mean(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
 
-  int AddN(
-    const vector<string>& a, vector<string>& output,
-    const attr_type* attr_info = nullptr);
+  int Sum(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
+
+  int AddN(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
 
   ////////////////////////////////// nn ops //////////////////////////////////
-  int Relu(
-    const vector<string>& a, vector<string>& output,
-    const attr_type* attr_info = nullptr);
-  
+  int Relu(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
+
   int ReluPrime(
-    const vector<string>& a, vector<string>& output,
+    const vector<string>& a,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int Sigmoid(
-    const vector<string>& a, vector<string>& output,
+    const vector<string>& a,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
 
   int SigmoidCrossEntropy(
-    const vector<string>& a, const vector<string>& b, vector<string>& output,
-    const attr_type* attr_info = nullptr);
-
-  int Reveal(
-    const vector<string>& a, vector<string>& output,
-    const attr_type* attr_info = nullptr);
-
-  int Reveal(
     const vector<string>& a,
-    vector<double>& output,
+    const vector<string>& b,
+    vector<string>& output,
     const attr_type* attr_info = nullptr);
-    
+
+  int Reveal(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
+  int Reveal(const vector<string>& a, vector<double>& output, const attr_type* attr_info = nullptr);
+
+  ////////////////////////////////// logical ops //////////////////////////////////
+  int AND(
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
+    const attr_type* attr_info = nullptr);
+  int OR(
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
+    const attr_type* attr_info = nullptr);
+  int XOR(
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
+    const attr_type* attr_info = nullptr);
+  int NOT(const vector<string>& a, vector<string>& output, const attr_type* attr_info = nullptr);
 
   /**
     @desc: This is for Tensorflow's SaveV2 Op.
-
   */
-  int ConditionalReveal(vector<string>& in_vec,
-                        vector<string>& out_cipher_vec,
-                        vector<double>& out_plain_vec);
-public:
-  shared_ptr<NET_IO> GetNetHandler() { return net_io_;}
+  int ConditionalReveal(
+    vector<string>& in_vec,
+    vector<string>& out_cipher_vec,
+    vector<double>& out_plain_vec);
 
-public:
+ public:
+  shared_ptr<NET_IO> GetNetHandler() { return net_io_; }
+
+ public:
   shared_ptr<NET_IO> net_io_ = nullptr;
-
 };
 
 //} // namespace protocol

--- a/cc/modules/protocol/mpc/snn/tests/snn_log.cpp
+++ b/cc/modules/protocol/mpc/snn/tests/snn_log.cpp
@@ -12,7 +12,9 @@ void run(int partyid) {
 
   string msgid("All basic Binary OP(s) (share,share)");
   cout << __FUNCTION__ << " " << msgid << endl;
-  
+    vector<string> strX, strZ;
+  vector<string> zZ(strZ.size());
+
   vector<string> half_share_X = {"2.0", "10.0"};
   print_vec(half_share_X, 10, "Half_share {2, 10}");
   vector<string> half_share_log(size);
@@ -22,21 +24,47 @@ void run(int partyid) {
   snn0.GetOps(msgid)->Reveal(half_share_log, half_share_revealed);
   print_vec(half_share_revealed, 10, "Log half_share revealed zZ:");  
 
-  vector<string> strX, strZ;
+
+
   snn0.GetOps(msgid)->PrivateInput(0, X, strX);
 
   snn0.GetOps(msgid)->Log(strX, strZ);
 
-  vector<string> zZ(strZ.size());
+
   snn0.GetOps(msgid)->Reveal(strZ, zZ);
   print_vec(zZ, 10, "SNN Log plaintext:");
   print_vec(EXPECT, 10, "Log expected:");
 
+  snn0.StartPerfStats();
   snn0.GetOps(msgid)->HLog(strX, strZ);
   print_vec(strZ, 10, "HLog strZ:");
+  auto perf = snn0.GetPerfStats();
+  cout << "HLog perf stat:" << perf.to_json(true) << endl;
+
   snn0.GetOps(msgid)->Reveal(strZ, zZ);
   print_vec(zZ, 10, "SNN HLog plaintext:");
   print_vec(EXPECT, 10, "HLog expected:");
+
+
+  vector<double> logits = {-10.0, -3.0, 10.0, 3.0,  5.0,  3.1, 0.003, -0.02};
+  vector<double> labels = {  0.0,  0.0,  1.0, 1.0, -1.0, -1.0,  -1.0,   1.0};
+  vector<double> SCE = {0.0, 0.04, 0.0001, 0.049, 10.007, 6.244, 0.698, 0.703};
+
+  vector<string> input_str1, input_str2, out_str;
+  snn0.GetOps(msgid)->PrivateInput(0, logits, input_str1);
+  snn0.GetOps(msgid)->PrivateInput(0, labels, input_str2);
+  print_vec(logits, 10, "logits:");
+  print_vec(labels, 10, "labels:");
+  attr_type attr;
+  
+  snn0.StartPerfStats();
+  snn0.GetOps(msgid)->SigmoidCrossEntropy(input_str1, input_str2, out_str, &attr);
+  cout << "SCE PERF:" << snn0.GetPerfStats().to_json(true) << endl;
+  // reveal c
+  vector<double> c;
+  snn0.GetOps(msgid)->Reveal(out_str, c);
+  print_vec(c, 10, "SigmoidCrossEntropy result plain:");
+  print_vec(SCE, 10, "SCE expected:");
 
   //////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////

--- a/cc/modules/protocol/mpc/snn/tests/snn_matmul.cpp
+++ b/cc/modules/protocol/mpc/snn/tests/snn_matmul.cpp
@@ -25,6 +25,8 @@ void run(int partyid) {
 
   SimpleTimer timer;
   snn0.GetOps(msgid)->Matmul(strX, strY, strZ, &attr);
+  snn0.GetOps(msgid)->Reveal(strZ, Z);
+  print_vec(Z, 20, "Matmul revealed result:");
   cout << ">>>>>>>>>>>>>>>>>>> timer:" << timer.elapse() << endl;
   //////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////

--- a/cc/modules/protocol/mpc/snn/tests/snn_maxmin.cpp
+++ b/cc/modules/protocol/mpc/snn/tests/snn_maxmin.cpp
@@ -1,0 +1,52 @@
+#include "snn__test.h"
+#include <string>
+using namespace std;
+void run(int partyid) {
+  SNN_PROTOCOL_TEST_INIT(partyid);
+  //////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////
+  /*
+  [[2.9 2.2 3.3]
+  [2.4 2.8 2.6]
+  [2.7 2.5 3.4]]
+  */
+  vector<double> X = {2.9, 2.2, 3.3, 2.4, 2.8, 2.6, 2.7, 2.5, 3.4};
+  vector<double> MAX_EXPECT = {3.3, 2.8, 3.4};
+  vector<double> MIN_EXPECT = {2.2, 2.4, 2.5};
+
+  size_t size = X.size();
+  print_vec(X, 10, "Input X");
+
+  string msgid("Max_and_Min");
+  cout << __FUNCTION__ << " " << msgid << endl;
+  
+  vector<string> strX(X.size()), strZ(X.size());
+  vector<string> zZ(strZ.size());
+
+  snn0.GetOps(msgid)->PrivateInput(0, X, strX);
+  snn0.GetOps(msgid)->Reveal(strX, zZ);
+  print_vec(zZ, 10, "check PrivateInput plaintext:");
+
+  cout << __FUNCTION__ << " " << msgid << endl;  
+  
+
+  attr_type attr;
+  attr["rows"] = "3";
+  attr["cols"] = "3";
+
+  snn0.GetOps(msgid)->Max(strX, strZ, &attr);
+  snn0.GetOps(msgid)->Reveal(strZ, zZ);
+  print_vec(zZ, 10, "Max plaintext:");
+  print_vec(MAX_EXPECT, 10, "Max expected:");
+
+  snn0.GetOps(msgid)->Min(strX, strZ, &attr);
+  snn0.GetOps(msgid)->Reveal(strZ, zZ);
+  print_vec(zZ, 10, "SNN Min plaintext:");
+  print_vec(MIN_EXPECT, 10, "Min expected:");
+
+  //////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////
+  SNN_PROTOCOL_TEST_UNINIT(partyid);
+}
+
+RUN_MPC_TEST(run);

--- a/cc/modules/protocol/mpc/tests/op_logical.cpp
+++ b/cc/modules/protocol/mpc/tests/op_logical.cpp
@@ -1,0 +1,141 @@
+// ==============================================================================
+// Copyright 2020 The LatticeX Foundation
+// This file is part of the Rosetta library.
+//
+// The Rosetta library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Rosetta library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Rosetta library. If not, see <http://www.gnu.org/licenses/>.
+// ==============================================================================
+// only for disable vscode warnings
+#ifndef PROTOCOL_MPC_TEST
+#define PROTOCOL_MPC_TEST_SNN 1
+#endif
+
+#include "test.h"
+
+void run(int partyid) {
+  PROTOCOL_MPC_TEST_INIT(partyid);
+  //////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////
+  // clang-format off
+  vector<double> X1 = {1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1};
+  vector<double> X2 = {0, 1, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0};
+  /////// X = X1>X2 = {1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1};
+  vector<double> Y1 = {1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1};
+  vector<double> Y2 = {0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 0};
+  /////// Y = Y1>Y2 = {1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1};
+  //
+  ///////////// AND : {1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1}
+  ///////////// XOR : {0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0}
+  /////////////  OR : {1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1}
+  //////////// NOTx : {0, 1, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0}
+  // clang-format on
+
+  string msgid("Logical ops");
+  cout << __FUNCTION__ << " " << msgid << endl;
+
+  vector<string> strX1, strY1, strX2, strY2, strZ1, strZ2;
+  mpc_proto->GetOps(msgid)->PrivateInput(0, X1, strX1);
+  mpc_proto->GetOps(msgid)->PrivateInput(1, X2, strX2);
+  mpc_proto->GetOps(msgid)->PrivateInput(2, Y1, strY1);
+  mpc_proto->GetOps(msgid)->PrivateInput(0, Y2, strY2);
+  mpc_proto->GetOps(msgid)->Greater(strX1, strX2, strZ1); // return X1 > X2
+  mpc_proto->GetOps(msgid)->Greater(strY1, strY2, strZ2); // return Y1 > Y2
+
+  //
+  vector<double> Z;
+  vector<string> strZ;
+  mpc_proto->GetOps(msgid)->Reveal(strZ1, Z);
+  print_vector(Z, "Z1", 10, 0);
+  mpc_proto->GetOps(msgid)->Reveal(strZ2, Z);
+  print_vector(Z, "Z2", 10, 0);
+
+  {
+    // variable vs variable
+    mpc_proto->GetOps(msgid)->AND(strZ1, strZ2, strZ);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, "AND Z", 10, 0);
+
+    mpc_proto->GetOps(msgid)->XOR(strZ1, strZ2, strZ);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, "XOR Z", 10, 0);
+
+    mpc_proto->GetOps(msgid)->OR(strZ1, strZ2, strZ);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, " OR Z", 10, 0);
+
+    mpc_proto->GetOps(msgid)->NOT(strZ1, strZ);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, "NOT Z1", 10, 0);
+  }
+
+  {
+    // constant vs variable
+    vector<string> strZ1 = {"1", "0", "0", "0", "1", "1", "1", "0", "1", "0", "1", "0", "1"};
+    attr_type attr;
+    attr["lh_is_const"] = "1";
+    mpc_proto->GetOps(msgid)->AND(strZ1, strZ2, strZ, &attr);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, ".AND Z", 10, 0);
+
+    mpc_proto->GetOps(msgid)->XOR(strZ1, strZ2, strZ, &attr);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, ".XOR Z", 10, 0);
+
+    mpc_proto->GetOps(msgid)->OR(strZ1, strZ2, strZ, &attr);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, ". OR Z", 10, 0);
+  }
+  {
+    // variable vs constant
+    vector<string> strZ2 = {"1", "0", "1", "1", "0", "1", "0", "0", "1", "0", "0", "0", "1"};
+    attr_type attr;
+    attr["rh_is_const"] = "1";
+    mpc_proto->GetOps(msgid)->AND(strZ1, strZ2, strZ, &attr);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, "AND. Z", 10, 0);
+
+    mpc_proto->GetOps(msgid)->XOR(strZ1, strZ2, strZ, &attr);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, "XOR. Z", 10, 0);
+
+    mpc_proto->GetOps(msgid)->OR(strZ1, strZ2, strZ, &attr);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, " OR. Z", 10, 0);
+  }
+  ////
+  //// unexpected behavier
+  {
+    cout << "unexpected behavier" << endl;
+    // variable vs constant
+    vector<string> strZ2 = {"1", "0", "3", "1", "0", "2", "0", "5", "1", "0", "0", "7", "1"};
+    attr_type attr;
+    attr["rh_is_const"] = "1";
+    mpc_proto->GetOps(msgid)->AND(strZ1, strZ2, strZ, &attr);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, "AND. Z", 10, 0);
+
+    mpc_proto->GetOps(msgid)->XOR(strZ1, strZ2, strZ, &attr);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, "XOR. Z", 10, 0);
+
+    mpc_proto->GetOps(msgid)->OR(strZ1, strZ2, strZ, &attr);
+    mpc_proto->GetOps(msgid)->Reveal(strZ, Z);
+    print_vector(Z, " OR. Z", 10, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////
+  PROTOCOL_MPC_TEST_UNINIT(partyid);
+}
+
+RUN_MPC_TEST(run);

--- a/cc/modules/protocol/public/include/protocol_ops.h
+++ b/cc/modules/protocol/public/include/protocol_ops.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <string>
 #include <iostream>
+#include "cc/modules/protocol/mpc/comm/include/mpc_defines.h"
 
 namespace rosetta {
 
@@ -66,7 +67,7 @@ class ProtocolOps {
 
   /**
    * @desc: encode the literal number to a protocol-specific format 
-   *         wrappered as string.
+   *         wrapped as string.
    * @param:
    *     in, the vector of literal number
    *     out, the vector of the encoded strings
@@ -93,6 +94,10 @@ class ProtocolOps {
   virtual uint64_t RandSeed(vector<uint64_t>& seed) { return 0x123456; }
 
   virtual int PrivateInput(int party_id, const vector<double>& in_x, vector<string>& out_x) {
+    THROW_NOT_IMPL;
+  }
+
+  virtual int Broadcast(int from_party, const string& msg, string& result) {
     THROW_NOT_IMPL;
   }
 
@@ -272,7 +277,7 @@ class ProtocolOps {
 
   /**
    * @desc: optional, for high-precision logarithm. 
-   *    The default implementaion in base class will use the Log.
+   *    The default implementation in base class will use the Log.
    */
   virtual int HLog(
     const vector<string>& a,
@@ -362,6 +367,34 @@ class ProtocolOps {
   virtual int Reveal(
     const vector<string>& a,
     vector<double>& output,
+    const attr_type* attr_info = nullptr) {
+    THROW_NOT_IMPL;
+  }
+  ////////////////////////////////// logical ops //////////////////////////////////
+  virtual int AND(
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
+    const attr_type* attr_info = nullptr) {
+    THROW_NOT_IMPL;
+  }
+  virtual int OR(
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
+    const attr_type* attr_info = nullptr) {
+    THROW_NOT_IMPL;
+  }
+  virtual int XOR(
+    const vector<string>& a,
+    const vector<string>& b,
+    vector<string>& output,
+    const attr_type* attr_info = nullptr) {
+    THROW_NOT_IMPL;
+  }
+  virtual int NOT(
+    const vector<string>& a,
+    vector<string>& output,
     const attr_type* attr_info = nullptr) {
     THROW_NOT_IMPL;
   }

--- a/cc/python_export/dataset.h
+++ b/cc/python_export/dataset.h
@@ -287,7 +287,7 @@ class DataSet {
         if (partyid == PARTY_A)
           valuesXX = valuesX;
         else
-          valuesXX.resize(n * dA);
+          valuesXX.resize(n * dA, 0);
         ops->PrivateInput(PARTY_A, valuesXX, SSA);
       }
       if (p1_has_data) {
@@ -295,7 +295,7 @@ class DataSet {
         if (partyid == PARTY_B)
           valuesXX = valuesX;
         else
-          valuesXX.resize(n * dB);
+          valuesXX.resize(n * dB, 0);
         ops->PrivateInput(PARTY_B, valuesXX, SSB);
       }
       if (p2_has_data) {
@@ -303,7 +303,7 @@ class DataSet {
         if (partyid == PARTY_C)
           valuesXX = valuesX;
         else
-          valuesXX.resize(n * dC);
+          valuesXX.resize(n * dC, 0);
         ops->PrivateInput(PARTY_C, valuesXX, SSC);
       }
 
@@ -403,7 +403,7 @@ class DataSet {
         if (partyid == PARTY_A)
           valuesXX = valuesX;
         else
-          valuesXX.resize(nA * d);
+          valuesXX.resize(nA * d, 0);
         ops->PrivateInput(PARTY_A, valuesXX, SSA);
       }
       if (p1_has_data) {
@@ -411,7 +411,7 @@ class DataSet {
         if (partyid == PARTY_B)
           valuesXX = valuesX;
         else
-          valuesXX.resize(nB * d);
+          valuesXX.resize(nB * d, 0);
         ops->PrivateInput(PARTY_B, valuesXX, SSB);
       }
       if (p2_has_data) {
@@ -419,7 +419,7 @@ class DataSet {
         if (partyid == PARTY_C)
           valuesXX = valuesX;
         else
-          valuesXX.resize(nC * d);
+          valuesXX.resize(nC * d, 0);
         ops->PrivateInput(PARTY_C, valuesXX, SSC);
       }
 
@@ -637,7 +637,7 @@ class DataSet {
         if (partyid == PARTY_A)
           valuesYY = valuesY;
         else
-          valuesYY.resize(nA * d);
+          valuesYY.resize(nA * d, 0);
         ops->PrivateInput(PARTY_A, valuesYY, SSA);
       }
       if (p1_has_data) {
@@ -645,7 +645,7 @@ class DataSet {
         if (partyid == PARTY_B)
           valuesYY = valuesY;
         else
-          valuesYY.resize(nB * d);
+          valuesYY.resize(nB * d, 0);
         ops->PrivateInput(PARTY_B, valuesYY, SSB);
       }
       if (p2_has_data) {
@@ -653,7 +653,7 @@ class DataSet {
         if (partyid == PARTY_C)
           valuesYY = valuesY;
         else
-          valuesYY.resize(nC * d);
+          valuesYY.resize(nC * d, 0);
         ops->PrivateInput(PARTY_C, valuesYY, SSC);
       }
 

--- a/cc/tf/rttops/math.cc
+++ b/cc/tf/rttops/math.cc
@@ -580,6 +580,45 @@ class RttGreaterEqualOp : public RttBinaryOp<Device> {
   }
 };
 
+// logical ops
+template <typename Device>
+class RttLogicalAndOp : public RttBinaryOp<Device> {
+ public:
+  explicit RttLogicalAndOp(OpKernelConstruction* context)  : RttBinaryOp<Device>(context, "RttLogicalAndOp") {}
+
+  std::shared_ptr<MatrixRtt> BinaryCompute(std::shared_ptr<MatrixRtt> matrix0, std::shared_ptr<MatrixRtt> matrix1) override {
+    throw;
+  }
+};
+template <typename Device>
+class RttLogicalOrOp : public RttBinaryOp<Device> {
+ public:
+  explicit RttLogicalOrOp(OpKernelConstruction* context)  : RttBinaryOp<Device>(context, "RttLogicalOrOp") {}
+
+  std::shared_ptr<MatrixRtt> BinaryCompute(std::shared_ptr<MatrixRtt> matrix0, std::shared_ptr<MatrixRtt> matrix1) override {
+    throw;
+  }
+};
+template <typename Device>
+class RttLogicalXorOp : public RttBinaryOp<Device> {
+ public:
+  explicit RttLogicalXorOp(OpKernelConstruction* context)  : RttBinaryOp<Device>(context, "RttLogicalXorOp") {}
+
+  std::shared_ptr<MatrixRtt> BinaryCompute(std::shared_ptr<MatrixRtt> matrix0, std::shared_ptr<MatrixRtt> matrix1) override {
+    throw;
+  }
+};
+template <typename Device>
+class RttLogicalNotOp : public OpKernel {
+ public:
+  explicit RttLogicalNotOp(OpKernelConstruction* context) : OpKernel(context) {}
+  
+  void Compute(OpKernelContext* context) {
+    PRINT_BEG("RttLogicalNotOp");
+    throw;
+  }
+};
+
 struct RttMeanFunctor {
   RttMeanFunctor() {}
   ~RttMeanFunctor() {}
@@ -746,5 +785,11 @@ REGISTER_KERNEL_BUILDER(Name("RttAbs").Device(DEVICE_CPU), RttAbsOp<CPUDevice>);
 REGISTER_KERNEL_BUILDER(Name("RttLog").Device(DEVICE_CPU), RttLogOp<CPUDevice>);
 REGISTER_KERNEL_BUILDER(Name("RttLog1p").Device(DEVICE_CPU), RttLog1pOp<CPUDevice>);
 REGISTER_KERNEL_BUILDER(Name("RttPow").Device(DEVICE_CPU), RttPowOp<CPUDevice>);
+
+// logical ops
+REGISTER_KERNEL_BUILDER(Name("RttLogicalAnd").Device(DEVICE_CPU), RttLogicalAndOp<CPUDevice>);
+REGISTER_KERNEL_BUILDER(Name("RttLogicalOr").Device(DEVICE_CPU), RttLogicalOrOp<CPUDevice>);
+REGISTER_KERNEL_BUILDER(Name("RttLogicalXor").Device(DEVICE_CPU), RttLogicalXorOp<CPUDevice>);
+REGISTER_KERNEL_BUILDER(Name("RttLogicalNot").Device(DEVICE_CPU), RttLogicalNotOp<CPUDevice>);
 
 } //namespace tensorflow

--- a/cc/tf/rttops/math_ops.cc
+++ b/cc/tf/rttops/math_ops.cc
@@ -20,9 +20,6 @@
 //#include "tensorflow/core/framework/shape_inference.h"
 
 
-
-
-
 #define REGISTER_RTT_BINARY_OP(name)                       \
   REGISTER_OP(#name)                                          \
     .Input("x: string")                                       \
@@ -94,6 +91,20 @@ REGISTER_RTT_BINARY_OP(RttGreaterEqual).Doc(R"doc(
 REGISTER_RTT_BINARY_OP(RttLessEqual).Doc(R"doc(
     RttLessEqual
 )doc");
+
+REGISTER_RTT_BINARY_OP(RttLogicalAnd).Doc(R"doc(
+    RttLogicalAnd
+)doc");
+REGISTER_RTT_BINARY_OP(RttLogicalOr).Doc(R"doc(
+    RttLogicalOr
+)doc");
+REGISTER_RTT_BINARY_OP(RttLogicalXor).Doc(R"doc(
+    RttLogicalXor
+)doc");
+REGISTER_OP("RttLogicalNot")
+  .Input("x: string")
+  .Output("y: string")
+  .SetIsStateful();
 
 REGISTER_OP("RttNegative")
   .Input("x: string")

--- a/cc/tf/secureops/secure_math.cc
+++ b/cc/tf/secureops/secure_math.cc
@@ -604,6 +604,56 @@ class SecureRevealOp : public StrUnaryOp {
   }
 };
 
+/////////////////////// logical ops //////////////////////////
+class SecureLogicalAndOp : public SecureBinaryOp {
+ public:
+  SecureLogicalAndOp(OpKernelConstruction* context) : SecureBinaryOp(context) {}
+  ~SecureLogicalAndOp() {}
+
+  int BinaryCompute(
+    const vector<string>& in1, const vector<string>& in2, vector<string>& output) {
+    ProtocolManager::Instance()->GetProtocol()->GetOps(msg_id().str())->AND(in1, in2, output, &attrs_);
+    return 0;
+  }
+};
+
+class SecureLogicalOrOp : public SecureBinaryOp {
+ public:
+  SecureLogicalOrOp(OpKernelConstruction* context) : SecureBinaryOp(context) {}
+  ~SecureLogicalOrOp() {}
+
+  int BinaryCompute(
+    const vector<string>& in1, const vector<string>& in2, vector<string>& output) {
+    ProtocolManager::Instance()->GetProtocol()->GetOps(msg_id().str())->OR(in1, in2, output, &attrs_);
+    return 0;
+  }
+};
+
+class SecureLogicalXorOp : public SecureBinaryOp {
+ public:
+  SecureLogicalXorOp(OpKernelConstruction* context) : SecureBinaryOp(context) {}
+  ~SecureLogicalXorOp() {}
+
+  int BinaryCompute(
+    const vector<string>& in1, const vector<string>& in2, vector<string>& output) {
+    ProtocolManager::Instance()->GetProtocol()->GetOps(msg_id().str())->XOR(in1, in2, output, &attrs_);
+    return 0;
+  }
+};
+
+class SecureLogicalNotOp : public StrUnaryOp {
+ private:
+  int receive_party_ = 0;
+ public:
+  SecureLogicalNotOp(OpKernelConstruction* context) : StrUnaryOp(context) {}
+  ~SecureLogicalNotOp() {}
+
+  int UnaryCompute(const vector<string>& input, vector<string>& output) {
+    ProtocolManager::Instance()->GetProtocol()->GetOps(msg_id().str())->NOT(input, output, &attrs_);
+    return 0;
+  }
+};
+
 //////////////    register kernels    //////////////
 REGISTER_STR_CPU_KERNEL(SecureAdd, SecureAddOp);
 REGISTER_STR_CPU_KERNEL(SecureSub, SecureSubOp);
@@ -638,4 +688,9 @@ REGISTER_STR_CPU_KERNEL(SecureReveal, SecureRevealOp);
 REGISTER_KERNEL_BUILDER(Name("SecureAddN").Device(DEVICE_CPU).TypeConstraint<std::string>("T"), \
                         SecureAddNOp);
 
+// logical ops
+REGISTER_STR_CPU_KERNEL(SecureLogicalAnd, SecureLogicalAndOp);
+REGISTER_STR_CPU_KERNEL(SecureLogicalOr, SecureLogicalOrOp);
+REGISTER_STR_CPU_KERNEL(SecureLogicalXor, SecureLogicalXorOp);
+REGISTER_STR_CPU_KERNEL(SecureLogicalNot, SecureLogicalNotOp);
 } // namespace tensorflow

--- a/cc/tf/secureops/secure_math_ops.cc
+++ b/cc/tf/secureops/secure_math_ops.cc
@@ -75,6 +75,20 @@ REGISTER_SECURE_BINARY_OP(SecureLessEqual).Doc(R"doc(
     SecureLessEqual
 )doc");
 
+REGISTER_SECURE_BINARY_OP(SecureLogicalAnd).Doc(R"doc(
+    SecureLogicalAnd
+)doc");
+REGISTER_SECURE_BINARY_OP(SecureLogicalOr).Doc(R"doc(
+    SecureLogicalOr
+)doc");
+REGISTER_SECURE_BINARY_OP(SecureLogicalXor).Doc(R"doc(
+    SecureLogicalXor
+)doc");
+REGISTER_OP("SecureLogicalNot")
+  .Input("x: string")
+  .Output("y: string")
+  .SetIsStateful();
+
 REGISTER_OP("SecureNegative")
   .Input("x: string")
   .Output("res: string")

--- a/cc/tf/secureops/secure_train.cc
+++ b/cc/tf/secureops/secure_train.cc
@@ -27,7 +27,7 @@ class SecureApplyGradientDescentOp : public SecureOpKernel {
   void Compute(OpKernelContext* ctx) override {
     log_debug << "begin debuging SecureApplyGradientDescentOp!" << endl;
     // Step 1: check the lock level and validity of inputs the same as the native one.
-    //  Note: For now, we do NOT support the exclusice_lock feature.
+    //  Note: For now, we do NOT support the exclusive_lock feature.
     OP_REQUIRES(
       ctx, use_exclusive_lock_ == false,
       errors::FailedPrecondition(
@@ -36,7 +36,7 @@ class SecureApplyGradientDescentOp : public SecureOpKernel {
     OP_REQUIRES(
       ctx, ctx->input_dtype(0) != DT_RESOURCE,
       errors::FailedPrecondition(
-        "In this MPC version, we do NOT support the 'ResourceVarible'-type variable."));
+        "In this MPC version, we do NOT support the 'ResourceVariable'-type variable."));
     Tensor var;
     //Tensor* var_p;
     var = ctx->mutable_input(0, use_exclusive_lock_);
@@ -89,7 +89,7 @@ class SecureApplyGradientDescentOp : public SecureOpKernel {
       ->GetOps(msg_id().str())
       ->Sub(input_var, out_var, out_var, &attrs_);
 
-    // TODO[georgeshi]: why we canot and need not use this?? due to string?
+    // TODO[GeorgeShi]: why we cannot and need not use this?? due to string?
     //new_var.setZero();
 
     for (int i = 0; i < ele_nums; ++i) {

--- a/cc/tf/secureops/secure_utils.h
+++ b/cc/tf/secureops/secure_utils.h
@@ -175,7 +175,7 @@ static std::shared_ptr<MatrixRtt> AdjustInputForBcast(
   }
 
   return vec;
-} //class AdjustInputForBcast
+} //AdjustInputForBcast
 
 } // namespace utils
 } // namespace rosetta

--- a/doc/API_DOC.md
+++ b/doc/API_DOC.md
@@ -32,6 +32,10 @@
       - [`SecureGreaterEqual(x, y, name=None, lh_is_const=False, rh_is_const=False)`](#securegreaterequalx-y-namenone-lh_is_constfalse-rh_is_constfalse)
       - [`SecureLess(x, y, name=None, lh_is_const=False, rh_is_const=False)`](#securelessx-y-namenone-lh_is_constfalse-rh_is_constfalse)
       - [`SecureLessEqual(x, y, name=None, lh_is_const=False, rh_is_const=False)`](#securelessequalx-y-namenone-lh_is_constfalse-rh_is_constfalse)
+      - [`SecureLogicalAnd(x, y, name=None, lh_is_const=False, rh_is_const=False)`](#securelogicalandx-y-namenone-lh_is_constfalse-rh_is_constfalse)
+      - [`SecureLogicalOr(x, y, name=None, lh_is_const=False, rh_is_const=False)`](#securelogicalorx-y-namenone-lh_is_constfalse-rh_is_constfalse)
+      - [`SecureLogicalXor(x, y, name=None, lh_is_const=False, rh_is_const=False)`](#securelogicalxorx-y-namenone-lh_is_constfalse-rh_is_constfalse)
+      - [`SecureLogicalNot(x, name=None)`](#securelogicalnotx-namenone)
       - [`SecureMatMul(a, b, transpose_a=False, transpose_b=False, name=None)`](#securematmula-b-transpose_afalse-transpose_bfalse-namenone)
       - [`SecurePow(x, y, name=None, lh_is_const=False, rh_is_const=True)`](#securepowx-y-namenone-lh_is_constfalse-rh_is_consttrue)
       - [`SecureLog(x, name=None)`](#securelogx-namenone)
@@ -440,7 +444,85 @@ We will try to represent each `SecureOp` interface in an clear and easy-to-under
    * Broadcasting is supported for this SecureOp.
    * The output values are still in the shared status, just like other `SecureOps`. So in the current version, **you should not use the local output `Tensor` in any following predicate clause directly.**
 
+#### `SecureLogicalAnd(x, y, name=None, lh_is_const=False, rh_is_const=False)`
   
+  Returns the truth value of `(x & y)` element-wise, as 0 for false and 1 for true.
+
+  **Args:**
+
+  - **`x`**: A  `Tensor` in TensorFlow, whose values are in shared status. 
+  - **`y`**: A `Tensor` in TensorFlow, whose values are in shared status. . Must have the same type as `x`.
+  - **`name(optional)`**: A name for the operation, the default value of it is None.
+  - **`lh_is_const(optional)`**: flag indicating whether the `x` is a const number. If it is set as True, the `x` will be added just as the sum of all parties' shared input pieces. The default value is `False`.
+  - **`rh_is_const(optional)`** :flag indicating whether the `y` is a const number. If it is set as True, the `y` will be added just as the sum of all parties' shared input pieces.The default value is `False`.
+
+  **Returns:**
+
+  ​	A `Tensor`. Has the same type as `x`.
+
+  *NOTE:* 
+
+   * Broadcasting is supported for this SecureOp.
+   * The output values are still in the shared status, just like other `SecureOps`. So in the current version, **you should not use the local output `Tensor` in any following predicate clause directly.**
+
+#### `SecureLogicalOr(x, y, name=None, lh_is_const=False, rh_is_const=False)`
+
+  Returns the truth value of `(x | y)` element-wise, as 0 for false and 1 for true.
+
+  **Args:**
+
+  - **`x`**: A  `Tensor` in TensorFlow, whose values are in shared status. 
+  - **`y`**: A `Tensor` in TensorFlow, whose values are in shared status. . Must have the same type as `x`.
+  - **`name(optional)`**: A name for the operation, the default value of it is None.
+  - **`lh_is_const(optional)`**: flag indicating whether the `x` is a const number. If it is set as True, the `x` will be added just as the sum of all parties' shared input pieces. The default value is `False`.
+  - **`rh_is_const(optional)`** :flag indicating whether the `y` is a const number. If it is set as True, the `y` will be added just as the sum of all parties' shared input pieces.The default value is `False`.
+
+  **Returns:**
+
+  ​	A `Tensor`. Has the same type as `x`.
+
+  *NOTE:* 
+
+   * Broadcasting is supported for this SecureOp.
+   * The output values are still in the shared status, just like other `SecureOps`. So in the current version, **you should not use the local output `Tensor` in any following predicate clause directly.**
+
+#### `SecureLogicalXor(x, y, name=None, lh_is_const=False, rh_is_const=False)`
+
+  Returns the truth value of `(x ^ y)` element-wise, as 0 for false and 1 for true.
+
+  **Args:**
+
+  - **`x`**: A  `Tensor` in TensorFlow, whose values are in shared status. 
+  - **`y`**: A `Tensor` in TensorFlow, whose values are in shared status. . Must have the same type as `x`.
+  - **`name(optional)`**: A name for the operation, the default value of it is None.
+  - **`lh_is_const(optional)`**: flag indicating whether the `x` is a const number. If it is set as True, the `x` will be added just as the sum of all parties' shared input pieces. The default value is `False`.
+  - **`rh_is_const(optional)`** :flag indicating whether the `y` is a const number. If it is set as True, the `y` will be added just as the sum of all parties' shared input pieces.The default value is `False`.
+
+  **Returns:**
+
+  ​	A `Tensor`. Has the same type as `x`.
+
+  *NOTE:* 
+
+   * Broadcasting is supported for this SecureOp.
+   * The output values are still in the shared status, just like other `SecureOps`. So in the current version, **you should not use the local output `Tensor` in any following predicate clause directly.**
+
+#### `SecureLogicalNot(x, name=None)`
+
+  Returns the truth value of `(!x)` element-wise, as 0 for false and 1 for true.
+
+  **Args:**
+
+  - **`x`**: A  `Tensor` in TensorFlow, whose values are in shared status. 
+  - **`name(optional)`**: A name for the operation, the default value of it is None.
+
+  **Returns:**
+
+  ​	A `Tensor`. Has the same type as `x`.
+
+  *NOTE:* 
+
+   * The output values are still in the shared status, just like other `SecureOps`. So in the current version, **you should not use the local output `Tensor` in any following predicate clause directly.**
 
 #### `SecureMatMul(a, b, transpose_a=False, transpose_b=False, name=None)`
 

--- a/doc/API_DOC_CN.md
+++ b/doc/API_DOC_CN.md
@@ -19,6 +19,10 @@
       - [`SecureGreaterEqual(x, y, name=None, lh_is_const=False, rh_is_const=False)`](#securegreaterequalx-y-namenone-lh_is_constfalse-rh_is_constfalse)
       - [`SecureLess(x, y, name=None, lh_is_const=False, rh_is_const=False)`](#securelessx-y-namenone-lh_is_constfalse-rh_is_constfalse)
       - [`SecureLessEqual(x, y, name=None, lh_is_const=False, rh_is_const=False)`](#securelessequalx-y-namenone-lh_is_constfalse-rh_is_constfalse)
+      - [`SecureLogicalAnd(x, y, name=None, lh_is_const=False, rh_is_const=False)`](#securelogicalandx-y-namenone-lh_is_constfalse-rh_is_constfalse)
+      - [`SecureLogicalOr(x, y, name=None, lh_is_const=False, rh_is_const=False)`](#securelogicalorx-y-namenone-lh_is_constfalse-rh_is_constfalse)
+      - [`SecureLogicalXor(x, y, name=None, lh_is_const=False, rh_is_const=False)`](#securelogicalxorx-y-namenone-lh_is_constfalse-rh_is_constfalse)
+      - [`SecureLogicalNot(x, name=None)`](#securelogicalnotx-namenone)
       - [`SecureMatMul(a, b, transpose_a=False, transpose_b=False, name=None)`](#securematmula-b-transpose_afalse-transpose_bfalse-namenone)
       - [`SecurePow(x, y, name=None, lh_is_const=False, rh_is_const=True)`](#securepowx-y-namenone-lh_is_constfalse-rh_is_consttrue)
       - [`SecureLog(x, name=None)`](#securelogx-namenone)
@@ -76,7 +80,7 @@
   - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
   - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
   - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `False`。
-  - **`rh_is_const(optional)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
 
   **返回值：**
 
@@ -96,7 +100,7 @@
   - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
   - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
   - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `False`。
-  - **`rh_is_const(optional)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
 
   **返回值：**
 
@@ -116,7 +120,7 @@
   - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
   - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
   - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `False`。
-  - **`rh_is_const(optional)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
 
   **返回值：**
 
@@ -137,7 +141,7 @@
   - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
   - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
   - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `False`。
-  - **`rh_is_const(optional)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
 
   **返回值：**
 
@@ -164,7 +168,7 @@
   - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
   - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
   - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `False`。
-  - **`rh_is_const(optional)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
 
   **返回值：**
 
@@ -198,7 +202,7 @@
   - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
   - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
   - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `False`。
-  - **`rh_is_const(optional)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
 
   **返回值：**
 
@@ -223,7 +227,7 @@
   - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
   - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
   - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `False`。
-  - **`rh_is_const(optional)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
 
   **返回值：**
 
@@ -247,7 +251,7 @@
   - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
   - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
   - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `False`。
-  - **`rh_is_const(optional)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
 
   **返回值：**
 
@@ -271,7 +275,7 @@
   - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
   - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
   - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `False`。
-  - **`rh_is_const(optional)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
 
   **返回值：**
 
@@ -294,7 +298,7 @@
   - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
   - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
   - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `False`。
-  - **`rh_is_const(optional)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
 
   **返回值：**
 
@@ -305,6 +309,81 @@
    * 这个SecureOp支持Tensorflow中的广播机制。
    * 由于和其他计算类算子一样，结果是密文共享状态的值，**所以不可以直接的在后续程序中直接的对此算子的结果进行判断类型语句的处理！**
 
+#### `SecureLogicalAnd(x, y, name=None, lh_is_const=False, rh_is_const=False)`
+
+  返回逐元素进行“逻辑与”比较的结果`(x & y)` 。结果对应的真实值为 $0.0$ 时表示假，$1.0$ 则表示真。
+
+  **参数:**
+
+  - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
+  - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 `None`。
+  - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值, 默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+
+  **返回值：**
+
+  一个 `Tensor`。类型与`x`相同。
+
+  *注意:* 
+
+   * 这个SecureOp支持Tensorflow中的广播机制。
+   * 由于和其他计算类算子一样，结果是密文共享状态的值，**所以不可以直接的在后续程序中直接的对此算子的结果进行判断类型语句的处理！**
+
+#### `SecureLogicalOr(x, y, name=None, lh_is_const=False, rh_is_const=False)`
+  返回逐元素进行“逻辑或”比较的结果`(x | y)` 。结果对应的真实值为 $0.0$ 时表示假，$1.0$ 则表示真。
+
+  **参数:**
+
+  - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
+  - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 `None`。
+  - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值, 默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+
+  **返回值：**
+
+  一个 `Tensor`。类型与`x`相同。
+
+  *注意:* 
+
+   * 这个SecureOp支持Tensorflow中的广播机制。
+   * 由于和其他计算类算子一样，结果是密文共享状态的值，**所以不可以直接的在后续程序中直接的对此算子的结果进行判断类型语句的处理！**
+
+#### `SecureLogicalXor(x, y, name=None, lh_is_const=False, rh_is_const=False)`
+  返回逐元素进行“逻辑异或”比较的结果`(x ^ y)` 。结果对应的真实值为 $0.0$ 时表示假，$1.0$ 则表示真。
+
+  **参数:**
+
+  - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
+  - **`y`**: TensorFlow中的`Tensor`，其值处于共享状态。且必须具有与`x`相同的`shape`。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 `None`。
+  - **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值, 默认值为 `False`。
+  - **`rh_is_const(可选)`** :标识`y`是否为常数。如果设置为`True`，那么`y `将被视为各方共享的输入值的综合，即真实值，默认值为 `False`。
+
+  **返回值：**
+
+  一个 `Tensor`。类型与`x`相同。
+
+  *注意:* 
+
+   * 这个SecureOp支持Tensorflow中的广播机制。
+   * 由于和其他计算类算子一样，结果是密文共享状态的值，**所以不可以直接的在后续程序中直接的对此算子的结果进行判断类型语句的处理！**
+
+#### `SecureLogicalNot(x, name=None)`
+  返回逐元素进行“逻辑非”比较的结果`!x` 。结果对应的真实值为 $0.0$ 时表示假，$1.0$ 则表示真。
+
+  **参数:**
+
+  - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 `None`。
+
+  **返回值：**
+
+  一个 `Tensor`。类型与`x`相同。
+
+  *注意:* 
+   * 由于和其他计算类算子一样，结果是密文共享状态的值，**所以不可以直接的在后续程序中直接的对此算子的结果进行判断类型语句的处理！**
   
 
 #### `SecureMatMul(a, b, transpose_a=False, transpose_b=False, name=None)`
@@ -317,11 +396,11 @@
 
   - **`b`**: TensorFlow中的 `Tensor`，其值处于共享状态。且必须要和`a`的维度相兼容。
 
-  - **`name(optional)`**: 指定的该操作的名称，默认值为 None。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
 
-  - **`transpose_a(optional)`**: 如果值为`True`, `a` 在执行矩阵乘法之前先执行转置操作。默认值为 `Flase`.
+  - **`transpose_a(可选)`**: 如果值为`True`, `a` 在执行矩阵乘法之前先执行转置操作。默认值为 `Flase`.
 
-  - **`transpose_b(optional)`**: 如果值为`True`, `b` 在执行矩阵乘法之前先执行转置操作。默认值为 `Flase`.
+  - **`transpose_b(可选)`**: 如果值为`True`, `b` 在执行矩阵乘法之前先执行转置操作。默认值为 `Flase`.
 
   **返回值:**
 
@@ -339,9 +418,9 @@
 
   - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
   - **`y`**: TensorFlow中的 `Tensor`。**在当前版本中，其中的每一个值都需要是常量整数，且各方的此值输入都相同。** 此外, `y` 和 `x`的`shape`要一致.
-  - **`lh_is_const(optional)`**: **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `False`。
-  - **`rh_is_const(optional)`** :**`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `True`。 **当前版本，仅支持设为`True`。 在后续版本中我们将支持此值可变** 
-  - **`name(optional)`**: 指定的该操作的名称，默认值为 None。
+  - **`lh_is_const(可选)`**: **`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `False`。
+  - **`rh_is_const(可选)`** :**`lh_is_const(可选)`**：标识`x`是否为常数。如果它被设置为`True`，那么`x`将被视为所有各方共享的输入值的总和，即真实值。默认值为 `True`。 **当前版本，仅支持设为`True`。 在后续版本中我们将支持此值可变** 
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
 
   **返回值:**
 
@@ -357,7 +436,7 @@
   **参数:**
 
   - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
-  - **`name(optional)`**: 指定的该操作的名称，默认值为 None。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
 
   **返回值:**
   
@@ -378,7 +457,7 @@
   **参数:**
 
   - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
-  - **`name(optional)`**: 指定的该操作的名称，默认值为 None。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
 
   **返回值:**
   
@@ -395,7 +474,7 @@
   **参数:**
 
   - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
-  - **`name(optional)`**: 指定的该操作的名称，默认值为 None。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
 
   **返回值:**
   
@@ -414,7 +493,7 @@
   **参数:**
 
   - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
-  - **`name(optional)`**: 指定的该操作的名称，默认值为 None。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
 
   **返回值:**
 
@@ -436,7 +515,7 @@
   **参数:**
 
   - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
-  - **`name(optional)`**: 指定的该操作的名称，默认值为 None。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
 
   **返回值:**
   
@@ -451,7 +530,7 @@
   **参数:**
 
   - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
-  - **`name(optional)`**: 指定的该操作的名称，默认值为 None。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
 
   **返回值:**
 
@@ -466,7 +545,7 @@
   **参数:**
 
   - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
-  - **`name(optional)`**: 指定的该操作的名称，默认值为 None。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
 
   **返回值:**
 
@@ -481,7 +560,7 @@
   **参数:**
 
   - **`x`**: TensorFlow中的 `Tensor`，其值处于共享状态。
-  - **`name(optional)`**: 指定的该操作的名称，默认值为 None。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
 
   **返回值:**
 
@@ -497,9 +576,9 @@
 
   - **`input_tensor`**: 待进行降维的`Tensor`. 
 
-  - **`axis(optional)`**: 指定待降维的维度。如果为`None`(默认值)，则在所有维度上进行降维。 **当前版本中支持设为0, 1 或 None.**
+  - **`axis(可选)`**: 指定待降维的维度。如果为`None`(默认值)，则在所有维度上进行降维。 **当前版本中支持设为0, 1 或 None.**
 
-  - **`name(optional)`**: 指定的该操作的名称，默认值为 None。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
 
     
 
@@ -517,9 +596,9 @@
 
   - **`input_tensor`**: 待进行降维的`Tensor`. 
 
-  - **`axis(optional)`**: 指定待降维的维度。如果为`None`(默认值)，则在所有维度上进行降维。 **当前版本中支持设为0, 1 或 None.**
+  - **`axis(可选)`**: 指定待降维的维度。如果为`None`(默认值)，则在所有维度上进行降维。 **当前版本中支持设为0, 1 或 None.**
 
-  - **`name(optional)`**: 指定的该操作的名称，默认值为 None。
+  - **`name(可选)`**: 指定的该操作的名称，默认值为 None。
 
     
   **返回值:**
@@ -564,7 +643,7 @@
   - **`tensor_name`**: `string`类型的 `Tensor` 。有${N}$个元素，用于指定具体需要保存的`Tensor`的自定义名称。 
   - **`shape_and_slices`**:`string`类型的 `Tensor` 。有${N}$个元素，用于指定具体需要保存的`Tensor`的具体切片配置。 
   - **`tensors`**: `Tensor` 对象列表，指定待保存的 $N$ 个`Tensor`。
-  - **`name(optional)`**: 指定的该操作的名称，默认为`None`。
+  - **`name(可选)`**: 指定的该操作的名称，默认为`None`。
 
   **返回值:**
 

--- a/python/latticex/rosetta/rtt/framework/rtt_tensor.py
+++ b/python/latticex/rosetta/rtt/framework/rtt_tensor.py
@@ -207,6 +207,29 @@ class RttTensor(object):
         res = rtt_ops.rtt_not_equal(self._raw, other._raw)
         return RttTensor(res)
 
+    def __and__(self, other):
+        """ self & other """
+        other = convert_to_rtttensor(other)
+        res = rtt_ops.rtt_logical_and(self._raw, other._raw)
+        return RttTensor(res)
+
+    def __or__(self, other):
+        """ self | other """
+        other = convert_to_rtttensor(other)
+        res = rtt_ops.rtt_logical_or(self._raw, other._raw)
+        return RttTensor(res)
+    
+    def __xor__(self, other):
+        """ self ^ other """
+        other = convert_to_rtttensor(other)
+        res = rtt_ops.rtt_logical_xor(self._raw, other._raw)
+        return RttTensor(res)
+
+    def __invert__(self):
+        """ !self """
+        res = rtt_ops.rtt_logical_not(self._raw)
+        return RttTensor(res)
+
     def __pow__(self, other):
         """ self ** other """
         other = convert_to_rtttensor(other)

--- a/python/latticex/rosetta/rtt/ops/rtt_math_ops.py
+++ b/python/latticex/rosetta/rtt/ops/rtt_math_ops.py
@@ -134,6 +134,37 @@ def rtt_lessequal(x, y, name=None):
     return rtt_ts.RttTensor(_result)
 
 
+def rtt_logical_and(x, y, name=None):
+    """Returns the truth value of (x & y) element-wise.."""
+    x = rtt_ts.convert_to_rtttensor(x)
+    y = rtt_ts.convert_to_rtttensor(y)
+    _result = rtt_ts.rtt_ops.rtt_logical_and(x._raw, y._raw, name=name)
+    return rtt_ts.RttTensor(_result)
+
+
+def rtt_logical_or(x, y, name=None):
+    """Returns the truth value of (x | y) element-wise."""
+    x = rtt_ts.convert_to_rtttensor(x)
+    y = rtt_ts.convert_to_rtttensor(y)
+    _result = rtt_ts.rtt_ops.rtt_logical_or(x._raw, y._raw, name=name)
+    return rtt_ts.RttTensor(_result)
+
+
+def rtt_logical_xor(x, y, name=None):
+    """Returns the truth value of (x ^ y) element-wise."""
+    x = rtt_ts.convert_to_rtttensor(x)
+    y = rtt_ts.convert_to_rtttensor(y)
+    _result = rtt_ts.rtt_ops.rtt_logical_xor(x._raw, y._raw, name=name)
+    return rtt_ts.RttTensor(_result)
+
+
+def rtt_logical_not(x, name=None):
+    """Returns the truth value of (!x) element-wise."""
+    x = rtt_ts.convert_to_rtttensor(x)
+    _result = rtt_ts.rtt_ops.rtt_logical_not(x._raw, name=name)
+    return rtt_ts.RttTensor(_result)
+
+
 def rtt_matmul(x, y, transpose_a=False, transpose_b=False, name=None):
     """Multiplies matrix `a` by matrix `b`, producing `a` * `b`."""
     x = rtt_ts.convert_to_rtttensor(x)
@@ -309,6 +340,10 @@ def static_override_tf_ops_to_rtt_ops():
     tf.greater_equal = rtt_greaterequal
     tf.less = rtt_less
     tf.less_equal = rtt_lessequal
+    tf.logical_and = rtt_logical_and
+    tf.logical_or = rtt_logical_or
+    tf.logical_xor = rtt_logical_xor
+    tf.logical_not = rtt_logical_not
     tf.matmul = rtt_matmul
     tf.square = rtt_square
     tf.pow = rtt_pow

--- a/python/latticex/rosetta/secure/decorator/__init__.py
+++ b/python/latticex/rosetta/secure/decorator/__init__.py
@@ -17,9 +17,9 @@
 # =============================================================================="
 # import secure ops
 from latticex.rosetta.secure.decorator.secure_arithmetic_ops_ import *
-from latticex.rosetta.secure.decorator.secure_logic_ops_  import *
+from latticex.rosetta.secure.decorator.secure_logical_ops_ import *
 from latticex.rosetta.secure.decorator.secure_compare_ops_ import *
-from latticex.rosetta.secure.decorator.secure_matrix_ops_  import *
+from latticex.rosetta.secure.decorator.secure_matrix_ops_ import *
 from latticex.rosetta.secure.decorator.secure_reduce_ops_ import *
 from latticex.rosetta.secure.decorator.secure_ml_ops_  import *
 

--- a/python/latticex/rosetta/secure/decorator/secure_arithmetic_ops_.py
+++ b/python/latticex/rosetta/secure/decorator/secure_arithmetic_ops_.py
@@ -26,36 +26,40 @@ from latticex.rosetta.secure.decorator.secure_base_ import _secure_ops
 # -----------------------------
 def SecureAdd(x, y, name=None, lh_is_const=False, rh_is_const=False):
     return _secure_ops.secure_add(x, y, name=name,
-                          lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+                                  lh_is_const=lh_is_const, rh_is_const=rh_is_const)
 
 
 def SecureSub(x, y, name=None, lh_is_const=False, rh_is_const=False):
     return _secure_ops.secure_sub(x, y, name=name,
-                          lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+                                  lh_is_const=lh_is_const, rh_is_const=rh_is_const)
 
 
 def SecureMul(x, y, name=None, lh_is_const=False, rh_is_const=False):
     return _secure_ops.secure_mul(x, y, name=name,
-                          lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+                                  lh_is_const=lh_is_const, rh_is_const=rh_is_const)
 
 
 def SecureDiv(x, y, name=None, lh_is_const=False, rh_is_const=False):
     return _secure_ops.secure_div(x, y, name=name,
-                          lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+                                  lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+
 
 def SecureRealDiv(x, y, name=None, lh_is_const=False, rh_is_const=False):
     return _secure_ops.secure_realdiv(x, y, name=name,
-                          lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+                                      lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+
 
 def SecureFloorDiv(x, y, name=None, lh_is_const=False, rh_is_const=False):
     return _secure_ops.secure_floordiv(x, y, name=name,
-                          lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+                                       lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+
 
 def SecureTruediv(x, y, name=None, lh_is_const=False, rh_is_const=False):
     return _secure_ops.secure_truediv(x, y, name=name,
-                              lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+                                      lh_is_const=lh_is_const, rh_is_const=rh_is_const)
 
-#TODO: to align with TwnsorFlow naming. Should change this to backend implementation in the future
+
+# TODO: to align with TwnsorFlow naming. Should change this to backend implementation in the future
 SecureDivide = SecureDiv
 
 
@@ -90,28 +94,28 @@ def SecureHLog(x, name=None):
 def SecureAbs(x, name=None):
     return _secure_ops.secure_abs(x, name=name)
 
+
 def SecureAbsPrime(x, name=None):
     return _secure_ops.secure_abs_prime(x, name=name)
 
 
 def SecureAddN(inputs, name=None):
-  if not inputs or not isinstance(inputs, (list, tuple)):
-    raise ValueError("inputs must be a list of at least one "
-                     "Tensor/IndexedSlices with the same dtype and shape")
-  inputs = ops.convert_n_to_tensor_or_indexed_slices(inputs)
-  if not all(isinstance(x, (ops.Tensor, ops.IndexedSlices)) for x in inputs):
-    raise ValueError("inputs must be a list of at least one "
-                     "Tensor/IndexedSlices with the same dtype and shape")
+    if not inputs or not isinstance(inputs, (list, tuple)):
+        raise ValueError("inputs must be a list of at least one "
+                         "Tensor/IndexedSlices with the same dtype and shape")
+    inputs = ops.convert_n_to_tensor_or_indexed_slices(inputs)
+    if not all(isinstance(x, (ops.Tensor, ops.IndexedSlices)) for x in inputs):
+        raise ValueError("inputs must be a list of at least one "
+                         "Tensor/IndexedSlices with the same dtype and shape")
 
-  if len(inputs) == 1:
-    if isinstance(inputs[0], ops.IndexedSlices):
-      values = ops.convert_to_tensor(inputs[0])
-    else:
-      values = inputs[0]
+    if len(inputs) == 1:
+        if isinstance(inputs[0], ops.IndexedSlices):
+            values = ops.convert_to_tensor(inputs[0])
+        else:
+            values = inputs[0]
 
-    if name:
-      return array_ops.identity(values, name=name)
-    return values
+        if name:
+            return array_ops.identity(values, name=name)
+        return values
 
-  return _secure_ops.secure_add_n(inputs, name=name)
-
+    return _secure_ops.secure_add_n(inputs, name=name)

--- a/python/latticex/rosetta/secure/decorator/secure_logical_ops_.py
+++ b/python/latticex/rosetta/secure/decorator/secure_logical_ops_.py
@@ -1,0 +1,42 @@
+# ==============================================================================
+# Copyright 2020 The LatticeX Foundation
+# This file is part of the Rosetta library.
+#
+# The Rosetta library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# The Rosetta library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with the Rosetta library. If not, see <http://www.gnu.org/licenses/>.
+# =============================================================================="
+import tensorflow as tf
+from latticex.rosetta.secure.decorator.secure_base_ import _secure_ops
+
+# -----------------------------
+# secure arithmetic logical ops
+# -----------------------------
+
+
+def SecureLogicalAnd(x, y, name=None, lh_is_const=False, rh_is_const=False):
+    return _secure_ops.secure_logical_and(x, y, name=name,
+                                          lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+
+
+def SecureLogicalOr(x, y, name=None, lh_is_const=False, rh_is_const=False):
+    return _secure_ops.secure_logical_or(x, y, name=name,
+                                         lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+
+
+def SecureLogicalXor(x, y, name=None, lh_is_const=False, rh_is_const=False):
+    return _secure_ops.secure_logical_xor(x, y, name=name,
+                                          lh_is_const=lh_is_const, rh_is_const=rh_is_const)
+
+
+def SecureLogicalNot(x, name=None):
+    return _secure_ops.secure_logical_not(x, name=name)

--- a/python/latticex/rosetta/secure/grads_ops/secure_nn_grad.py
+++ b/python/latticex/rosetta/secure/grads_ops/secure_nn_grad.py
@@ -27,7 +27,7 @@ from tensorflow.python.ops import gen_array_ops
 def SecureSigmoidCrossEntropyGrad(op, grad):
     """ The customized gradient for SecureSigmoidCrossEntropy Operator that is used
         in function sigmoid_cross_entropy_with_logits.
-        @note : the funtion is we use in the forward pass is 
+        @note : the function is we use in the forward pass is 
         max(logit, 0) - logit * label + log(1 + exp(-abs(logits))
         just as it is in Tendorflow.
         In the backward pass here, we use  - logits * labels + log(1 + exp(logits).

--- a/python/latticex/rosetta/secure/spass/secure_gradient_descent.py
+++ b/python/latticex/rosetta/secure/spass/secure_gradient_descent.py
@@ -25,9 +25,6 @@ from latticex.rosetta.rtt.framework import rtt_tensor as rtt_ts
 from latticex.rosetta.controller.common_util import rtt_get_logger
 
 
-
-
-
 class SecureGradientDescentOptimizer(tf.compat.v1.train.GradientDescentOptimizer):
     """
     # Secure GradientDescent optimizer, only override __init__ & minimize functions

--- a/python/latticex/rosetta/secure/spass/static_replace_pass.py
+++ b/python/latticex/rosetta/secure/spass/static_replace_pass.py
@@ -109,12 +109,18 @@ class StaticReplacePass():
                             "rttlessequal":   ["SecureLessEqual",self._create_secure_relational_op,      secure_ops.SecureLessEqual,  True],
                             "rttgreaterequal":["SecureGreaterEqual", self._create_secure_relational_op,  secure_ops.SecureGreaterEqual,True],
 
+                            # logical operation
+                            "rttlogicaland" : ["SecureLogicalAnd",self._create_secure_logical_op, secure_ops.SecureLogicalAnd, True],
+                            "rttlogicalor" :  ["SecureLogicalOr", self._create_secure_logical_op, secure_ops.SecureLogicalOr,  True],
+                            "rttlogicalxor" : ["SecureLogicalXor",self._create_secure_logical_op, secure_ops.SecureLogicalXor, True],
+                            "rttlogicalnot" : ["SecureLogicalNot",self._create_secure_unary_op,   secure_ops.SecureLogicalNot, False],
+
                             # reduce operation
                             "rttreducemin" :  ["SecureReduceMin", self._create_secure_reduce_op,  secure_ops.SecureMin,   False],
                             "rttreducemax" :  ["SecureReduceMax", self._create_secure_reduce_op,  secure_ops.SecureMax,   False],
                             "rttreducemean":  ["SecureReduceMean",self._create_secure_reduce_op,  secure_ops.SecureMean,  False],
                             "rttreducesum" :  ["SecureReduceSum", self._create_secure_reduce_op,  secure_ops.SecureSum,   False],
-                            }
+                        }
 
 
         # source graph variable dict, save the train variables
@@ -632,6 +638,21 @@ class StaticReplacePass():
     def _create_secure_relational_op(self, src_op, secure_op_name, secure_op, to_graph):
         """
         create secure relational op(eg: secureless\securegreater\securelessequal...)
+
+        :param src_op: source op instance, it's not secure op, it's tensorflow native op
+        :param secure_op_name: secure op name.
+        :param secure_op: secure op
+        :param to_graph: dest graph
+        :return: the secure op instance
+        """
+        secure_op_input_nums = 2
+        return self._create_secure_op_helper(src_op, secure_op_name, 
+                    secure_op_input_nums, secure_op, to_graph)
+
+
+    def _create_secure_logical_op(self, src_op, secure_op_name, secure_op, to_graph):
+        """
+        create secure logical op(eg: securelogicaland\securelogicalor\securelogicalnot...)
 
         :param src_op: source op instance, it's not secure op, it's tensorflow native op
         :param secure_op_name: secure op name.


### PR DESCRIPTION
This commit includes:
* some Logic operations are added, including `SecureLogicalAnd`, `SecureLogicalOr`, `SecureLogicalXor`, and `SecureLogicalNot`.
* `Pow` Operation is refined, so that one call of Multiplication is reduced in each invocation.
* `ReduceMin`、`ReduceMax` are refined, so that the complexity is sub-linear with the number of elements in the target axis. This is achieved by using binary-tree strategy;
* `Division` and `FloorDivision` with one-side constant value are refined, both of them are only based on multiplication and truncation now to speedup it up greatly.
* `SigmoidCrossEntropy` and `Sigmoid` are refined, by using batch-vectorization to reduce their practical communication rounds;

Besides, we also fix some typos and code-style issues.